### PR TITLE
Updated to WhatsApp 2.2316.6

### DIFF
--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -1,4 +1,4 @@
-._27K43 /*normal message*/,
+.cm280p3y.to2l77zo.n1yiu2zv.c6f98ldp.ooty25bp.oq31bsqd /*normal message*/,
 .NQl4z > .ItfyB  /*blue info bar*/
 {
   filter: blur(8px) grayscale(1);
@@ -25,7 +25,7 @@
   transition-delay: 0s;
 }
 
-._27K43:hover /*normal message*/,
+.cm280p3y.to2l77zo.n1yiu2zv.c6f98ldp.ooty25bp.oq31bsqd:hover /*normal message*/,
 .NQl4z > .ItfyB:hover /*blue info bar*/,
 .ocd2b0bc:hover /*image, video*/,
 .rku33uoa:hover /*file*/,

--- a/src/css/textInput.css
+++ b/src/css/textInput.css
@@ -1,9 +1,9 @@
-.to2l77zo /*textarea*/
+.to2l77zo.gfz4du6o.ag5g9lrv.bze30y65.kao4egtt /*textarea*/
 {
   filter: grayscale(1) opacity(0.25);
 }
 
-.to2l77zo:hover /*textarea*/
+.to2l77zo.gfz4du6o.ag5g9lrv.bze30y65.kao4egtt:hover /*textarea*/
 {
   filter: grayscale(0) opacity(1);
   transition-delay: 0.3s;


### PR DESCRIPTION
The current implementation's classes refer textInput and message bubbles as the same element, so the blur wasn't working.

I updated the classes for textInput and messages to treat them as a different element.