### PR TITLE
Fix blur for Media Previews, sticker in All Messages, Names, and Profile Pictures

### DIFF
--- a/src/css/mediaPreview.css
+++ b/src/css/mediaPreview.css
@@ -1,21 +1,31 @@
-._2AOIt div[data-testid^="media-"] div /*image/video*/,
-._2AOIt div[data-testid^="image-"] div /*image/video*/,
-._2AOIt div[data-testid^="document-"] div /*document*/,
-._2AOIt img[data-testid^="link-"] /*link*/,
+._2AOIt div.ktbp76dp div[role="button"] img /*image landscape*/,
+._2AOIt div.eu4mztcy div[role="button"] img /*image potrait*/,
+._2AOIt div.ktbp76dp > div[role="button"] /*video landscape*/,
+._2AOIt div.eu4mztcy > div[role="button"] /*video potrait*/,
+._2AOIt .cm280p3y > div[role="button"] > div.g0rxnol2.fe3aadhc.g0rxnol2.ln8gz9je /*document image*/,
+._2AOIt .cm280p3y > div[role="button"] > div > div > div:not(:last-child) /*document*/,
+._2AOIt .M6sU5 /*link*/,
+._1BOF7 ._3cupO > div:not(.LldYr) /*link list*/,
+._3V9pc /* gif */,
 .kknmh /*media reply thumb*/,
 ._2MmTH /*media send preview*/,
-._1qNn2 ._1nCcB div:first-child /*Sticker*/
+.ZRhsD._2foMf /*Sticker*/
 {
   filter: blur(20px) grayscale(1);
   transition-delay: 0s;
 }
-._2AOIt div[data-testid^="media-"]:hover div /*image/video*/,
-._2AOIt div[data-testid^="image-"]:hover div /*image/video*/,
-._2AOIt div[data-testid^="document-"]:hover div /*document*/,
-._2AOIt img[data-testid^="link-"]:hover /*link*/,
+._2AOIt div.ktbp76dp div[role="button"]:hover img /*image landscape*/,
+._2AOIt div.eu4mztcy div[role="button"]:hover img /*image potrait*/,
+._2AOIt div.ktbp76dp > div[role="button"]:hover /*video landscape*/,
+._2AOIt div.eu4mztcy > div[role="button"]:hover /*video potrait*/,
+._2AOIt .cm280p3y > div[role="button"] > div.g0rxnol2.fe3aadhc.g0rxnol2.ln8gz9je:hover /*document image*/,
+._2AOIt .cm280p3y > div[role="button"] > div > div > div:not(:last-child):hover /*document*/,
+._2AOIt .M6sU5:hover /*link*/,
+._1BOF7 ._3cupO > div:not(.LldYr):hover /*link list*/,
+._3V9pc:hover /* gif */,
 .kknmh:hover /*media reply thumb*/,
 ._2MmTH:hover /*media send preview*/,
-._1qNn2 ._1nCcB:hover div:first-child  /*Sticker*/
+.ZRhsD._2foMf:hover /*Sticker*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/mediaPreview.css
+++ b/src/css/mediaPreview.css
@@ -9,7 +9,11 @@
 ._3V9pc /* gif */,
 .kknmh /*media reply thumb*/,
 ._2MmTH /*media send preview*/,
-.ZRhsD._2foMf /*Sticker*/
+.ZRhsD._2foMf /*Sticker*/,
+.Efdtr /* name in contact attachment */,
+.djhxrpsl /* name in multi contact attachment */,
+._3dPH0 /* contacts attachment */,
+.b021xdil /* multi contacts attachment */
 {
   filter: blur(20px) grayscale(1);
   transition-delay: 0s;
@@ -25,7 +29,11 @@
 ._3V9pc:hover /* gif */,
 .kknmh:hover /*media reply thumb*/,
 ._2MmTH:hover /*media send preview*/,
-.ZRhsD._2foMf:hover /*Sticker*/
+.ZRhsD._2foMf:hover /*Sticker*/,
+.Efdtr:hover /* name in contact attachment */,
+.djhxrpsl:hover /* name in multi contact attachment */,
+._3dPH0:hover /* contacts attachment */,
+.b021xdil:hover /* multi contacts attachment */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -1,4 +1,5 @@
 ._2AOIt div:first-child /*normal message*/,
+._3cupO /*link list message*/,
 ._1BOF7 ._1sykI /*blue info bar*/
 {
   filter: blur(8px) grayscale(1);
@@ -10,19 +11,20 @@
   padding-top: 12px !important;
   padding-bottom: 12px !important;
 }
-._1Fw-f /*sticker*/
+._1qNn2 ._1nCcB /*sticker*/
 {
   filter: blur(20px) grayscale(1);
   transition-delay: 0s;
 }
 ._2AOIt:hover div:first-child /*normal message*/,
-._1Fw-f:hover, /*sticker*/
+._3cupO:hover /*link list message*/,
+._1qNn2 ._1nCcB:hover, /*sticker*/
 ._1BOF7 ._1sykI:hover /*blue info bar*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
 }
-._1Fw-f /*set pseudo background on sticker*/
+._1qNn2 ._1nCcB /*set pseudo background on sticker*/
 {
   background-color: var(--incoming-background) !important;
   border-radius: 7.5px !important;

--- a/src/css/name.css
+++ b/src/css/name.css
@@ -1,25 +1,29 @@
-._21S-L /*List user/group name*/,
+div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L /*user/group name in search message*/,
+div[role="row"] > div > ._8nE1Y ._21S-L /*user/group name in message list*/,
+div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list*/,
 ._3W2ap /*Top user/group name*/,
-div[data-testid="chat-subtitle"] /*Top group user preview*/,
-._2HCBh ._1mDG- /*Details groupname*/,
+._2au8k div:nth-child(2) /*Top group user preview*/,
+._2HCBh ._1N-sl ._1mDG- /*Details groupname*/,
 .q9lllk4z /*Details username */,
-.kjemk6od /*Starred messages username*/,
-.qt60bha0 /*About user phone number*/,
-._8nE1Y ._2KKXC /*About user*/,
+.qfejxiq4 .Mk0Bp._30scZ /*Details username business*/,
+.njub1g37 span._11JPr /*Starred messages user/group name*/,
+.a4ywakfo.qt60bha0 /*About user phone number*/,
 ._3IzYj /*Message in chat*/
 {
   filter: blur(5px) grayscale(1);
   transition-delay: 0s;
 }
 
-._21S-L:hover /*List user/group name*/,
+div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L:hover /*user/group name in search message*/,
+div[role="row"] > div > ._8nE1Y ._21S-L:hover /*user/group name in message list*/,
+div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non message list*/,
 ._3W2ap:hover /*Top user/group name*/,
-div[data-testid="chat-subtitle"]:hover /*Top group user preview*/,
-._2HCBh:hover ._1mDG- /*Details groupname*/,
+._2au8k div:nth-child(2):hover /*Top group user preview*/,
+._2HCBh:hover ._1N-sl ._1mDG- /*Details groupname*/,
 .q9lllk4z:hover /*Details username */,
-.kjemk6od:hover /*Starred messages username*/,
-.qt60bha0:hover /*About user phone number*/,
-._8nE1Y:hover ._2KKXC /*About user*/,
+.qfejxiq4 .Mk0Bp._30scZ:hover /*Details username business*/,
+.njub1g37 span._11JPr:hover /*Starred messages user/group name*/,
+.a4ywakfo.qt60bha0:hover /*About user phone number*/,
 ._3IzYj:hover /*Message in chat*/
 {
   filter: blur(0) grayscale(0);

--- a/src/css/name.css
+++ b/src/css/name.css
@@ -8,7 +8,9 @@ div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list
 .qfejxiq4 .Mk0Bp._30scZ /*Details username business*/,
 .njub1g37 span._11JPr /*Starred messages user/group name*/,
 .a4ywakfo.qt60bha0 /*About user phone number*/,
-._3IzYj /*Message in chat*/
+._3IzYj /*Message in chat*/,
+.Efdtr /* name in contact attachment */,
+.djhxrpsl /* name in multi contact attachment */
 {
   filter: blur(5px) grayscale(1);
   transition-delay: 0s;
@@ -24,7 +26,9 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 .qfejxiq4 .Mk0Bp._30scZ:hover /*Details username business*/,
 .njub1g37 span._11JPr:hover /*Starred messages user/group name*/,
 .a4ywakfo.qt60bha0:hover /*About user phone number*/,
-._3IzYj:hover /*Message in chat*/
+._3IzYj:hover /*Message in chat*/,
+.Efdtr:hover /* name in contact attachment */,
+.djhxrpsl:hover /* name in multi contact attachment */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -18,7 +18,8 @@
 
 /* messages */
 ._2AOIt:hover div:first-child /*normal message*/,
-._1Fw-f:hover, /*sticker*/
+._3cupO:hover /*link list message*/,
+._1qNn2 ._1nCcB:hover /*sticker*/,
 ._1BOF7 ._1sykI:hover /*blue info bar*/,
 
 /* messagesPreview */

--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -3,13 +3,18 @@
 ._1Pr6q:hover /*media preview in send media*/,
 
 /* mediaPreview */
-._2AOIt div[data-testid^="media-"]:hover div /*image/video*/,
-._2AOIt div[data-testid^="image-"]:hover div /*image/video*/,
-._2AOIt div[data-testid^="document-"]:hover div /*document*/,
-._2AOIt img[data-testid^="link-"]:hover /*link*/,
+._2AOIt div.ktbp76dp div[role="button"]:hover img /*image landscape*/,
+._2AOIt div.eu4mztcy div[role="button"]:hover img /*image potrait*/,
+._2AOIt div.ktbp76dp > div[role="button"]:hover /*video landscape*/,
+._2AOIt div.eu4mztcy > div[role="button"]:hover /*video potrait*/,
+._2AOIt .cm280p3y > div[role="button"] > div.g0rxnol2.fe3aadhc.g0rxnol2.ln8gz9je:hover /*document image*/,
+._2AOIt .cm280p3y > div[role="button"] > div > div > div:not(:last-child):hover /*document*/,
+._2AOIt .M6sU5:hover /*link*/,
+._1BOF7 ._3cupO > div:not(.LldYr):hover /*link list*/,
+._3V9pc:hover /* gif */,
 .kknmh:hover /*media reply thumb*/,
 ._2MmTH:hover /*media send preview*/,
-._1qNn2 ._1nCcB:hover div:first-child  /*Sticker*/,
+.ZRhsD._2foMf:hover /*Sticker*/,
 
 /* messages */
 ._2AOIt:hover div:first-child /*normal message*/,

--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -20,23 +20,28 @@
 .vQ0w7:hover /*message preview*/,
 
 /* name */
-._21S-L:hover /*List user/group name*/,
+div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L:hover /*user/group name in search message*/,
+div[role="row"] > div > ._8nE1Y ._21S-L:hover /*user/group name in message list*/,
+div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non message list*/,
 ._3W2ap:hover /*Top user/group name*/,
-div[data-testid="chat-subtitle"]:hover /*Top group user preview*/,
-._2HCBh:hover ._1mDG- /*Details groupname*/,
+._2au8k div:nth-child(2):hover /*Top group user preview*/,
+._2HCBh:hover ._1N-sl ._1mDG- /*Details groupname*/,
 .q9lllk4z:hover /*Details username */,
-.kjemk6od:hover /*Starred messages username*/,
-.qt60bha0:hover /*About user phone number*/,
-._8nE1Y:hover ._2KKXC /*About user*/,
+.qfejxiq4 .Mk0Bp._30scZ:hover /*Details username business*/,
+.njub1g37 span._11JPr:hover /*Starred messages user/group name*/,
+.a4ywakfo.qt60bha0:hover /*About user phone number*/,
 ._3IzYj:hover /*Message in chat*/,
 
 /* profilePic */
-._13jwn:hover /*profile pic message list*/,
+[role="row"] > div > ._1AHcd ._13jwn:hover /*profile pic message list*/,
+[role="button"] > div > ._1AHcd ._13jwn:hover /*profile pic non message list*/,
 ._2pr2H:hover /*message view profile pic*/,
 ._3WByx:hover /*self profile pic*/,
 .stnyektq:hover /*group chat msg profile pic*/,
+._3oha0._2xaO4:hover /* voice message profile pic */,
 .pz0xruzv:hover /*Details direct profile pic*/,
-.njub1g37:hover /*Details group profile pic*/,
+.njub1g37 ._3xH7K:hover /*Details group profile pic*/,
+.njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/,
 
 /* textInput */
 ._3Uu1_:hover /*textarea*/

--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -37,6 +37,8 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 .njub1g37 span._11JPr:hover /*Starred messages user/group name*/,
 .a4ywakfo.qt60bha0:hover /*About user phone number*/,
 ._3IzYj:hover /*Message in chat*/,
+.Efdtr:hover /* name in contact attachment */,
+.djhxrpsl:hover /* name in multi contact attachment */,
 
 /* profilePic */
 [role="row"] > div > ._1AHcd ._13jwn:hover /*profile pic message list*/,
@@ -45,6 +47,8 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 ._3WByx:hover /*self profile pic*/,
 .stnyektq:hover /*group chat msg profile pic*/,
 ._3oha0._2xaO4:hover /* voice message profile pic */,
+._3dPH0:hover /* contacts attachment */,
+.b021xdil:hover /* multi contacts attachment */,
 .pz0xruzv:hover /*Details direct profile pic*/,
 .njub1g37 ._3xH7K:hover /*Details group profile pic*/,
 .njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/,

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -3,7 +3,9 @@
 ._2pr2H /*message view profile pic*/,
 ._3WByx /*self profile pic*/,
 .stnyektq /*group chat msg profile pic*/,
-._3oha0._2xaO4 /* voice message profile pic */
+._3oha0._2xaO4 /* voice message profile pic */,
+._3dPH0 /* contacts attachment */,
+.b021xdil /* multi contacts attachment */
 {
   filter: blur(7px) grayscale(1);
   transition-delay: 0s;
@@ -26,6 +28,8 @@
 ._3WByx:hover /*self profile pic*/,
 .stnyektq:hover /*group chat msg profile pic*/,
 ._3oha0._2xaO4:hover /* voice message profile pic */,
+._3dPH0:hover /* contacts attachment */,
+.b021xdil:hover /* multi contacts attachment */,
 .pz0xruzv:hover /*Details direct profile pic*/,
 .njub1g37 ._3xH7K:hover /*Details group profile pic*/,
 .njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -1,24 +1,34 @@
-._13jwn /*profile pic message list*/,
+[role="row"] > div > ._1AHcd ._13jwn /*profile pic message list*/,
+[role="button"] > div > ._1AHcd ._13jwn /*profile pic non message list*/,
 ._2pr2H /*message view profile pic*/,
 ._3WByx /*self profile pic*/,
-.stnyektq /*group chat msg profile pic*/
+.stnyektq /*group chat msg profile pic*/,
+._3oha0._2xaO4 /* voice message profile pic */
 {
   filter: blur(7px) grayscale(1);
   transition-delay: 0s;
 }
 .pz0xruzv /*Details direct profile pic*/,
-.njub1g37 /*Details group profile pic*/
+.njub1g37 ._3xH7K /*Details group profile pic*/
 {
   filter: blur(12px) grayscale(1);
   transition-delay: 0s;
 }
+.njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/
+{
+  filter: blur(3px) grayscale(1);
+  transition-delay: 0s;
+}
 
-._13jwn:hover /*profile pic message list*/,
+[role="row"] > div > ._1AHcd ._13jwn:hover /*profile pic message list*/,
+[role="button"] > div > ._1AHcd ._13jwn:hover /*profile pic non message list*/,
 ._2pr2H:hover /*message view profile pic*/,
 ._3WByx:hover /*self profile pic*/,
 .stnyektq:hover /*group chat msg profile pic*/,
+._3oha0._2xaO4:hover /* voice message profile pic */,
 .pz0xruzv:hover /*Details direct profile pic*/,
-.njub1g37:hover /*Details group profile pic*/
+.njub1g37 ._3xH7K:hover /*Details group profile pic*/,
+.njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -37,6 +37,8 @@ body:hover .qfejxiq4 .Mk0Bp._30scZ /*Details username business*/,
 body:hover .njub1g37 span._11JPr /*Starred messages user/group name*/,
 body:hover .a4ywakfo.qt60bha0 /*About user phone number*/,
 body:hover ._3IzYj /*Message in chat*/,
+body:hover .Efdtr /* name in contact attachment */,
+body:hover .djhxrpsl /* name in multi contact attachment */,
 
 /* profilePic */
 body:hover [role="row"] > div > ._1AHcd ._13jwn /*profile pic message list*/,
@@ -45,6 +47,8 @@ body:hover ._2pr2H /*message view profile pic*/,
 body:hover ._3WByx /*self profile pic*/,
 body:hover .stnyektq /*group chat msg profile pic*/,
 body:hover ._3oha0._2xaO4 /* voice message profile pic */,
+body:hover ._3dPH0 /* contacts attachment */,
+body:hover .b021xdil /* multi contacts attachment */,
 body:hover .pz0xruzv /*Details direct profile pic*/,
 body:hover .njub1g37 ._3xH7K /*Details group profile pic*/,
 body:hover .njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -20,23 +20,28 @@ body:hover ._1BOF7 ._1sykI /*blue info bar*/,
 body:hover .vQ0w7 /*message preview*/,
 
 /* name */
-body:hover ._21S-L /*List user/group name*/,
+body:hover div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L /*user/group name in search message*/,
+body:hover div[role="row"] > div > ._8nE1Y ._21S-L /*user/group name in message list*/,
+body:hover div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list*/,
 body:hover ._3W2ap /*Top user/group name*/,
-body:hover div[data-testid="chat-subtitle"] /*Top group user preview*/,
-body:hover ._2HCBh ._1mDG- /*Details groupname*/,
+body:hover ._2au8k div:nth-child(2) /*Top group user preview*/,
+body:hover ._2HCBh ._1N-sl ._1mDG- /*Details groupname*/,
 body:hover .q9lllk4z /*Details username */,
-body:hover .kjemk6od /*Starred messages username*/,
-body:hover .qt60bha0 /*About user phone number*/,
-body:hover ._8nE1Y ._2KKXC /*About user*/,
+body:hover .qfejxiq4 .Mk0Bp._30scZ /*Details username business*/,
+body:hover .njub1g37 span._11JPr /*Starred messages user/group name*/,
+body:hover .a4ywakfo.qt60bha0 /*About user phone number*/,
 body:hover ._3IzYj /*Message in chat*/,
 
 /* profilePic */
-body:hover ._13jwn /*profile pic message list*/,
+body:hover [role="row"] > div > ._1AHcd ._13jwn /*profile pic message list*/,
+body:hover [role="button"] > div > ._1AHcd ._13jwn /*profile pic non message list*/,
 body:hover ._2pr2H /*message view profile pic*/,
 body:hover ._3WByx /*self profile pic*/,
 body:hover .stnyektq /*group chat msg profile pic*/,
+body:hover ._3oha0._2xaO4 /* voice message profile pic */,
 body:hover .pz0xruzv /*Details direct profile pic*/,
-body:hover .njub1g37 /*Details group profile pic*/
+body:hover .njub1g37 ._3xH7K /*Details group profile pic*/,
+body:hover .njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0s;

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -3,13 +3,18 @@ body:hover .tukmaf4q /*media preview in gallery*/,
 body:hover ._1Pr6q /*media preview in send media*/,
 
 /* mediaPreview */
-body:hover ._2AOIt div[data-testid^="media-"] div /*image/video*/,
-body:hover ._2AOIt div[data-testid^="image-"] div /*image/video*/,
-body:hover ._2AOIt div[data-testid^="document-"] div /*document*/,
-body:hover ._2AOIt img[data-testid^="link-"] /*link*/,
+body:hover ._2AOIt div.ktbp76dp div[role="button"] img /*image landscape*/,
+body:hover ._2AOIt div.eu4mztcy div[role="button"] img /*image potrait*/,
+body:hover ._2AOIt div.ktbp76dp > div[role="button"] /*video landscape*/,
+body:hover ._2AOIt div.eu4mztcy > div[role="button"] /*video potrait*/,
+body:hover ._2AOIt .cm280p3y > div[role="button"] > div.g0rxnol2.fe3aadhc.g0rxnol2.ln8gz9je /*document image*/,
+body:hover ._2AOIt .cm280p3y > div[role="button"] > div > div > div:not(:last-child) /*document*/,
+body:hover ._2AOIt .M6sU5 /*link*/,
+body:hover ._1BOF7 ._3cupO > div:not(.LldYr) /*link list*/,
+body:hover ._3V9pc /* gif */,
 body:hover .kknmh /*media reply thumb*/,
 body:hover ._2MmTH /*media send preview*/,
-body:hover ._1qNn2 ._1nCcB div:first-child  /*Sticker*/,
+body:hover .ZRhsD._2foMf /*Sticker*/,
 
 /* messages */
 body:hover ._2AOIt div:first-child /*normal message*/,

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -18,7 +18,8 @@ body:hover .ZRhsD._2foMf /*Sticker*/,
 
 /* messages */
 body:hover ._2AOIt div:first-child /*normal message*/,
-body:hover ._1Fw-f, /*sticker*/
+body:hover ._3cupO /*link list message*/,
+body:hover ._1qNn2 ._1nCcB /*sticker*/,
 body:hover ._1BOF7 ._1sykI /*blue info bar*/,
 
 /* messagesPreview */


### PR DESCRIPTION
Fixing for issue #49 
and maybe for issue #42 and #46

Tested in 
 - OS: Windows 10 version 22H2 build 19045.3803
 - Browser: Chrome v120.0.6099.217, Brave v1.61.116 Chromium v120.0.6099.217, Firefox v121.0.1
 - Whatsapp v2.2402.5

Note that contact attachment get blurred by media preview toggle, and also by profile pic and name toggle, The blur amount is different, but I think that is fine. I use the same selectors.

> Btw, I found out that the order of stylesheets doesn't depend on the order of the toggle, and I think it should be in a fixed order.

Please review, and thank you @LukasLen 