### PR TITLE
Update to support WhatsApp Version 2.3000.xx

### DIFF
--- a/src/css/mediaGallery.css
+++ b/src/css/mediaGallery.css
@@ -2,16 +2,35 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 .tukmaf4q /*media preview in gallery*/,
-._1Pr6q /*media preview in send media*/
+._1Pr6q /*media preview in send media*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ajuf._ajuh._ajug > div /* media in overlay view */,
+div.x1conndi /* media thumb in overlay view and details panel */,
+div.x4t2iug /* media thumb in media gallery panel */
 {
-  filter: blur(12px) grayscale(1);
+  filter: blur(20px) grayscale(1);
   transition-delay: 0s;
 }
 
+/* former wa version (v2.2412.xx) */
 .tukmaf4q:hover /*media preview in gallery*/,
-._1Pr6q:hover /*media preview in send media*/
+._1Pr6q:hover /*media preview in send media*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ajuf._ajuh._ajug > div:hover /* media in overlay view */,
+div.x1conndi:hover /* media thumb in overlay view and details panel */,
+div.x4t2iug:hover /* media thumb in media gallery panel */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
+}
+
+/* updated wa version (v2.3000.xx) */
+/* prevent cropped blur */
+div[role="dialog"] > .x10wlt62 /* media thumb in details panel */
+{
+  overflow: visible;
 }

--- a/src/css/mediaPreview.css
+++ b/src/css/mediaPreview.css
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 ._2AOIt div.ktbp76dp div[role="button"] img /*image landscape*/,
 ._2AOIt div.eu4mztcy div[role="button"] img /*image potrait*/,
 ._2AOIt div.ktbp76dp > div[role="button"] /*video landscape*/,
@@ -17,11 +18,25 @@
 .Efdtr /* name in contact attachment */,
 .djhxrpsl /* name in multi contact attachment */,
 ._3dPH0 /* contacts attachment */,
-.b021xdil /* multi contacts attachment */
+.b021xdil /* multi contacts attachment */,
+
+/* updated wa version (v2.3000.xx) */
+div._amk4 > ._amk6 :is(div, button)[role="button"]:not(.x13yyeie, ._ak3u, [data-js-context-icon]) /* media messages in chat panel (also quoted message and contact attachment button) */,
+div._ak4o /* voice note / audio in chat panel */,
+div._ahy5 > div /* link preview in chat panel */,
+div._ak15 > ._ahwq /* some link preview in link list panel */,
+span._ajxd._ajxk > ._ajxj._ajxd /* sticker in chat panel */,
+div.xz9dduz > div:first-child /* maps / location */,
+div._ajwt > div:first-child > div:nth-child(2) > div /* media preview in send media */,
+div._ak3i /* media preview thumb in send media */,
+div._ajwt .xm0mufa > div /* document filename in send media */
 {
   filter: blur(20px) grayscale(1);
+  transition: initial; /* fix link preview delay */
   transition-delay: 0s;
 }
+
+/* former wa version (v2.2412.xx) */
 ._2AOIt div.ktbp76dp div[role="button"]:hover img /*image landscape*/,
 ._2AOIt div.eu4mztcy div[role="button"]:hover img /*image potrait*/,
 ._2AOIt div.ktbp76dp > div[role="button"]:hover /*video landscape*/,
@@ -37,12 +52,29 @@
 .Efdtr:hover /* name in contact attachment */,
 .djhxrpsl:hover /* name in multi contact attachment */,
 ._3dPH0:hover /* contacts attachment */,
-.b021xdil:hover /* multi contacts attachment */
+.b021xdil:hover /* multi contacts attachment */,
+
+/* updated wa version (v2.3000.xx) */
+div._amk4 > ._amk6 :is(div, button)[role="button"]:not(.x13yyeie, ._ak3u, [data-js-context-icon]):hover /* media messages in chat panel (also quoted message and contact attachment button) */,
+div._ak4o:hover /* voice note / audio in chat panel */,
+div._ahy5 > div:hover /* link preview in chat panel */,
+div._ak15 > ._ahwq:hover /* some link preview in link list panel */,
+span._ajxd._ajxk > ._ajxj._ajxd:hover /* sticker in chat panel */,
+div.xz9dduz > div:first-child:hover /* maps / location */,
+div._ajwt > div:first-child > div:nth-child(2) > div:hover /* media preview in send media */,
+div._ak3i:hover /* media preview thumb in send media */,
+div._ajwt .xm0mufa > div:hover /* document filename in send media */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
 }
-._1qNn2 ._1nCcB /*set pseudo background on sticker*/
+
+
+/* former wa version (v2.2412.xx) */
+._1qNn2 ._1nCcB /*set pseudo background on sticker*/,
+
+/* updated wa version (v2.3000.xx) */
+span._ajxd._ajxk > ._ajxj._ajxd /*set pseudo background on sticker*/
 {
   background-color: var(--incoming-background) !important;
   border-radius: 7.5px !important;

--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -2,33 +2,51 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 ._2AOIt div:first-child /*normal message*/,
 ._3cupO /*link list message*/,
-._1BOF7 ._1sykI /*blue info bar*/
+._1BOF7 ._1sykI /*blue info bar*/,
+
+/* updated wa version (v2.3000.xx) */
+div._amk4 > ._amk6 /* normal message text */,
+div._amk4 ._am2s /* sticker message */
 {
   filter: blur(8px) grayscale(1);
   transition-delay: 0s;
 }
+/* former wa version (v2.2412.xx) */
 ._2AOIt /*normal message more padding*/
 {
   padding-right: 40px !important;
   padding-top: 12px !important;
   padding-bottom: 12px !important;
 }
+/* former wa version (v2.2412.xx) */
 ._1qNn2 ._1nCcB /*sticker*/
 {
   filter: blur(20px) grayscale(1);
   transition-delay: 0s;
 }
+
+/* former wa version (v2.2412.xx) */
 ._2AOIt:hover div:first-child /*normal message*/,
 ._3cupO:hover /*link list message*/,
 ._1qNn2 ._1nCcB:hover, /*sticker*/
-._1BOF7 ._1sykI:hover /*blue info bar*/
+._1BOF7 ._1sykI:hover /*blue info bar*/,
+
+/* updated wa version (v2.3000.xx) */
+div._amk4 > ._amk6:hover /* normal message text */,
+div._amk4 ._am2s:hover /* sticker message */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
 }
-._1qNn2 ._1nCcB /*set pseudo background on sticker*/
+
+/* former wa version (v2.2412.xx) */
+._1qNn2 ._1nCcB /*set pseudo background on sticker*/,
+
+/* updated wa version (v2.3000.xx) */
+div._amk4 ._am2s /* set pseudo background on sticker */
 {
   background-color: var(--incoming-background) !important;
   border-radius: 7.5px !important;

--- a/src/css/messagesPreview.css
+++ b/src/css/messagesPreview.css
@@ -2,13 +2,21 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
-.vQ0w7 /*message preview*/
+/* former wa version (v2.2412.xx) */
+.vQ0w7 /*message preview*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ak8j /*message preview*/
 {
   filter: blur(8px) grayscale(1);
   transition-delay: 0s;
 }
 
-.vQ0w7:hover /*message preview*/
+/* former wa version (v2.2412.xx) */
+.vQ0w7:hover /*message preview*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ak8j:hover /*message preview*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/name.css
+++ b/src/css/name.css
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L /*user/group name in search message*/,
 div[role="row"] > div > ._8nE1Y ._21S-L /*user/group name in message list*/,
 div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list*/,
@@ -14,12 +15,37 @@ div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list
 .a4ywakfo.qt60bha0 /*About user phone number*/,
 ._3IzYj /*Message in chat*/,
 .Efdtr /* name in contact attachment */,
-.djhxrpsl /* name in multi contact attachment */
+.djhxrpsl /* name in multi contact attachment */,
+
+/* updated wa version (v2.3000.xx) */
+div[role="row"] ._ak8q /* user/group name in message list */,
+div[role="button"][class=""] ._ak8q /* user/group name in details list and popup list */,
+div[role="dialog"] ._ak8q /* user name in contact popup list */,
+div[role="dialog"] div.copyable-text /* phone number and business user name in contact popup list */,
+div[role="row"] ._am_2 /* community name */,
+div[role="button"]._amie > div:nth-child(1) /* user/group name at the top of chat panel */,
+div[role="button"]._amie > div:nth-child(2) /* user/group details at the top of chat panel */,
+div._ahxj /* user name in group chat messages */,
+div._ahz1 /* user name in contact attachment */,
+div.xs83m0k.x1iyjqo2.xdl72j9.x18wx58x.x6ikm8r.x10wlt62 /* user name in multiple contacts attachment */,
+div.overlay ._ak8q /* user name in overlay media view */,
+h2.xngnso2.x1fcty0u.x2b8uid /* user name in details info*/,
+div.x2b8uid.x193iq5w.xqmxbcd /* group name in details info */,
+div.x1evy7pa.x1gslohp /* user phone number in details info*/,
+span.x1lkfr7t.xdbd6k5.x1fcty0u.xw2npq5:nth-child(2) /* user phone number in details info*/,
+div.x1evy7pa.x1kgmq87.x2b8uid /* group short details in details info */,
+div.xlm9qay.x1s688f.x1e56ztr /* business user name in details info */,
+div.xlm9qay.x1s688f.x1e56ztr + div /* business short details in details info */,
+div.x2b8uid > .xzueoph + div /* business category in details info */,
+div.xkhd6sd:not([role]) > ._ajxu > div /* business about in details info */,
+div.xkhd6sd._ajxt > ._ajxu > div /* business phone number details in details info */,
+div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */
 {
   filter: blur(5px) grayscale(1);
   transition-delay: 0s;
 }
 
+/* former wa version (v2.2412.xx) */
 div:not([role]) > div:not([role]) > ._8nE1Y ._21S-L:hover /*user/group name in search message*/,
 div[role="row"] > div > ._8nE1Y ._21S-L:hover /*user/group name in message list*/,
 div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non message list*/,
@@ -32,8 +58,39 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 .a4ywakfo.qt60bha0:hover /*About user phone number*/,
 ._3IzYj:hover /*Message in chat*/,
 .Efdtr:hover /* name in contact attachment */,
-.djhxrpsl:hover /* name in multi contact attachment */
+.djhxrpsl:hover /* name in multi contact attachment */,
+
+/* updated wa version (v2.3000.xx) */
+div[role="row"] ._ak8q:hover /* user/group name in message list */,
+div[role="button"][class=""] ._ak8q:hover /* user/group name in details list and popup list */,
+div[role="dialog"] ._ak8q:hover /* user name in contact popup list */,
+div[role="dialog"] div.copyable-text:hover /* phone number and business user name in contact popup list */,
+div[role="row"] ._am_2:hover /* community name */,
+div[role="button"]._amie > div:nth-child(1):hover /* user/group name at the top of chat panel */,
+div[role="button"]._amie > div:nth-child(2):hover /* user/group details at the top of chat panel */,
+div._ahxj:hover /* user name in group chat messages */,
+div._ahz1:hover /* user name in contact attachment */,
+div.xs83m0k.x1iyjqo2.xdl72j9.x18wx58x.x6ikm8r.x10wlt62:hover /* user name in multiple contacts attachment */,
+div.overlay ._ak8q:hover /* user name in overlay media view */,
+h2.xngnso2.x1fcty0u.x2b8uid:hover /* user name in details info */,
+div.x2b8uid.x193iq5w.xqmxbcd:hover /* group name in details info */,
+div.x1evy7pa.x1gslohp:hover /* user phone number in details info*/,
+span.x1lkfr7t.xdbd6k5.x1fcty0u.xw2npq5:nth-child(2):hover /* user phone number in details info*/,
+div.x1evy7pa.x1kgmq87.x2b8uid:hover /* group short details in details info */,
+div.xlm9qay.x1s688f.x1e56ztr:hover /* business user name in details info */,
+div.xlm9qay.x1s688f.x1e56ztr + div:hover /* business short details in details info */,
+div.x2b8uid > .xzueoph + div:hover /* business category in details info */,
+div.xkhd6sd:not([role]) > ._ajxu > div:hover /* business about in details info */,
+div.xkhd6sd._ajxt > ._ajxu > div:hover /* business phone number in details info */,
+div._ak1d > div:first-child > div:first-child > :not(:first-child):hover /* user/group name in starred message list */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
+}
+
+/* updated wa version (v2.3000.xx) */
+/* prevent cropped blur */
+div._ak1d > div:first-child > div:first-child /* user/group name in starred message list */
+{
+  overflow: visible;
 }

--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 /* mediaGallery */
 .tukmaf4q:hover /*media preview in gallery*/,
 ._1Pr6q:hover /*media preview in send media*/,
@@ -58,7 +59,76 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 .njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/,
 
 /* textInput */
-._3Uu1_:hover /*textarea*/
+._3Uu1_:hover /*textarea*/,
+
+/* updated wa version (v2.3000.xx) */
+/* mediaGallery */
+div._ajuf._ajuh._ajug > div:hover /* media in overlay view */,
+div.x1conndi:hover /* media thumb in overlay view and details panel */,
+div.x4t2iug:hover /* media thumb in media gallery panel */,
+
+/* mediaPreview */
+div._amk4 > ._amk6 :is(div, button)[role="button"]:not(.x13yyeie, ._ak3u, [data-js-context-icon]):hover /* media messages in chat panel (also quoted message and contact attachment button) */,
+div._ak4o:hover /* voice note / audio in chat panel */,
+div._ahy5 > div:hover /* link preview in chat panel */,
+div._ak15 > ._ahwq:hover /* some link preview in link list panel */,
+span._ajxd._ajxk > ._ajxj._ajxd:hover /* sticker in chat panel */,
+div.xz9dduz > div:first-child:hover /* maps / location */,
+div._ajwt > div:first-child > div:nth-child(2) > div:hover /* media preview in send media */,
+div._ak3i:hover /* media preview thumb in send media */,
+div._ajwt .xm0mufa > div:hover /* document filename in send media */,
+
+/* messages */
+div._amk4 > ._amk6:hover /* normal message text */,
+div._amk4 ._am2s:hover /* sticker message */,
+
+/* messagesPreview */
+div._ak8j:hover /* message preview */,
+
+/* name */
+div[role="row"] ._ak8q:hover /* user/group name in message list */,
+div[role="button"][class=""] ._ak8q:hover /* user/group name in details list and popup list */,
+div[role="dialog"] ._ak8q:hover /* user name in contact popup list */,
+div[role="dialog"] div.copyable-text:hover /* phone number and business user name in contact popup list */,
+div[role="row"] ._am_2:hover /* community name */,
+div[role="button"]._amie > div:nth-child(1):hover /* user/group name at the top of chat panel */,
+div[role="button"]._amie > div:nth-child(2):hover /* user/group details at the top of chat panel */,
+div._ahxj:hover /* user name in group chat messages */,
+div._ahz1:hover /* user name in contact attachment */,
+div.xs83m0k.x1iyjqo2.xdl72j9.x18wx58x.x6ikm8r.x10wlt62:hover /* user name in multiple contacts attachment */,
+div.overlay ._ak8q:hover /* user name in overlay media view */,
+h2.xngnso2.x1fcty0u.x2b8uid:hover /* user name in details info */,
+div.x2b8uid.x193iq5w.xqmxbcd:hover /* group name in details info */,
+div.x1evy7pa.x1gslohp:hover /* user phone number in details info*/,
+span.x1lkfr7t.xdbd6k5.x1fcty0u.xw2npq5:nth-child(2):hover /* user phone number in details info*/,
+div.x1evy7pa.x1kgmq87.x2b8uid:hover /* group short details in details info */,
+div.xlm9qay.x1s688f.x1e56ztr:hover /* business user name in details info */,
+div.xlm9qay.x1s688f.x1e56ztr + div:hover /* business short details in details info */,
+div.x2b8uid > .xzueoph + div:hover /* business category in details info */,
+div.xkhd6sd:not([role]) > ._ajxu > div:hover /* business about in details info */,
+div.xkhd6sd._ajxt > ._ajxu > div:hover /* business phone number in details info */,
+div._ak1d > div:first-child > div:first-child > :not(:first-child):hover /* user/group name in starred message list */,
+
+/* profilePic */
+div[role="row"] ._ak8h:hover /* user/group profile pic in message list */,
+div[role="button"][class=""] ._ak8h:hover /* user/group profile pic in details list and popup list */,
+div[role="dialog"] ._ak8h:hover /* user/group profile pic in details list and popup list */,
+header._amid div[role="button"]:first-child > div:hover /* user/group profile pic at the top of chat panel */,
+div._amk4 > div[role="button"]:hover /* user profile pic in group chat messages */,
+div._ahz2:hover /* user profile pic in contact attachment */,
+div.x2lah0s.x1c4vz4f.xdl72j9.x194xeti:hover /* user profile pic in multiple contact attachment */,
+div._ak4m:hover /* user profile pic in voice note chat */,
+div.overlay ._ak8h:hover /* user profile pic in overlay media view */,
+div.x78zum5.xl56j7k.x1fqp7bg > div[role="button"]:hover /* user profile pic in details panel */,
+div[role="button"][class="x1n2onr6 x14yjl9h xudhj91 x18nykt9 xww2gxu"]:hover /* business profile pic in details panel */,
+div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1:hover /* business profile banner in details panel */,
+div.x15e7hw7:hover /* business profile banner in catalog list */,
+div._amje:hover /* group profile pic in details panel */,
+div.overlay ._am0k:hover /* user/group profile pic overlay view */,
+div.x1okw0bk.x1w0mnb:hover /* user profile pic in starred message list */,
+
+/* textInput */
+div._ak1l:hover /* message text input */
 {
   transition-delay: 0.04s !important;
   -webkit-transition-duration: 0s !important;

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 [role="row"] > div > ._1AHcd ._13jwn /*profile pic message list*/,
 [role="button"] > div > ._1AHcd ._13jwn /*profile pic non message list*/,
 ._2pr2H /*message view profile pic*/,
@@ -9,23 +10,48 @@
 .stnyektq /*group chat msg profile pic*/,
 ._3oha0._2xaO4 /* voice message profile pic */,
 ._3dPH0 /* contacts attachment */,
-.b021xdil /* multi contacts attachment */
+.b021xdil /* multi contacts attachment */,
+
+/* updated wa version (v2.3000.xx) */
+div[role="row"] ._ak8h /* user/group profile pic in message list */,
+div[role="button"][class=""] ._ak8h /* user/group profile pic in details list and popup list */,
+div[role="dialog"] ._ak8h /* user/group profile pic in details list and popup list */,
+header._amid div[role="button"]:first-child > div /* user/group profile pic at the top of chat panel */,
+div._amk4 > div[role="button"] /* user profile pic in group chat messages */,
+div._ahz2 /* user profile pic in contact attachment */,
+div.x2lah0s.x1c4vz4f.xdl72j9.x194xeti /* user profile pic in multiple contact attachment */,
+div._ak4m /* user profile pic in voice note chat */,
+div.overlay ._ak8h /* user profile pic in overlay media view */
 {
   filter: blur(7px) grayscale(1);
   transition-delay: 0s;
 }
+/* former wa version (v2.2412.xx) */
 .pz0xruzv /*Details direct profile pic*/,
-.njub1g37 ._3xH7K /*Details group profile pic*/
+.njub1g37 ._3xH7K /*Details group profile pic*/,
+
+/* updated wa version (v2.3000.xx) */
+div.x78zum5.xl56j7k.x1fqp7bg > div[role="button"] /* user profile pic in details panel */,
+div[role="button"][class="x1n2onr6 x14yjl9h xudhj91 x18nykt9 xww2gxu"] /* business profile pic in details panel */,
+div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1 /* business profile banner in details panel */,
+div.x15e7hw7 /* business profile banner in catalog list */,
+div._amje /* group profile pic in details panel */,
+div.overlay ._am0k /* user/group profile pic overlay view */
 {
   filter: blur(12px) grayscale(1);
   transition-delay: 0s;
 }
-.njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/
+/* former wa version (v2.2412.xx) */
+.njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/,
+
+/* updated wa version (v2.3000.xx) */
+div.x1okw0bk.x1w0mnb /* user profile pic in starred message list */
 {
   filter: blur(3px) grayscale(1);
   transition-delay: 0s;
 }
 
+/* former wa version (v2.2412.xx) */
 [role="row"] > div > ._1AHcd ._13jwn:hover /*profile pic message list*/,
 [role="button"] > div > ._1AHcd ._13jwn:hover /*profile pic non message list*/,
 ._2pr2H:hover /*message view profile pic*/,
@@ -36,8 +62,34 @@
 .b021xdil:hover /* multi contacts attachment */,
 .pz0xruzv:hover /*Details direct profile pic*/,
 .njub1g37 ._3xH7K:hover /*Details group profile pic*/,
-.njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/
+.njub1g37 .kk3akd72.claouzo6:hover /*Starred message profile pic*/,
+
+/* updated wa version (v2.3000.xx) */
+div[role="row"] ._ak8h:hover /* user/group profile pic in message list */,
+div[role="button"][class=""] ._ak8h:hover /* user/group profile pic in details list and popup list */,
+div[role="dialog"] ._ak8h:hover /* user/group profile pic in details list and popup list */,
+header._amid div[role="button"]:first-child > div:hover /* user/group profile pic at the top of chat panel */,
+div._amk4 > div[role="button"]:hover /* user profile pic in group chat messages */,
+div._ahz2:hover /* user profile pic in contact attachment */,
+div.x2lah0s.x1c4vz4f.xdl72j9.x194xeti:hover /* user profile pic in multiple contact attachment */,
+div._ak4m:hover /* user profile pic in voice note chat */,
+div.overlay ._ak8h:hover /* user profile pic in overlay media view */,
+div.x78zum5.xl56j7k.x1fqp7bg > div[role="button"]:hover /* user profile pic in details panel */,
+div[role="button"][class="x1n2onr6 x14yjl9h xudhj91 x18nykt9 xww2gxu"]:hover /* business profile pic in details panel */,
+div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1:hover /* business profile banner in details panel */,
+div.x15e7hw7:hover /* business profile banner in catalog list */,
+div._amje:hover /* group profile pic in details panel */,
+div.overlay ._am0k:hover /* user/group profile pic overlay view */,
+div.x1okw0bk.x1w0mnb:hover /* user profile pic in starred message list */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;
+}
+
+
+/* updated wa version (v2.3000.xx) */
+/* prevent cropped blur */
+div._ak1d > div:first-child > div:first-child /* user profile pic in starred message list */
+{
+  overflow: visible;
 }

--- a/src/css/textInput.css
+++ b/src/css/textInput.css
@@ -2,12 +2,20 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
-._3Uu1_ /*textarea*/
+/* former wa version (v2.2412.xx) */
+._3Uu1_ /*textarea*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ak1l /* message text input */
 {
   filter: grayscale(1) opacity(0.25);
 }
 
-._3Uu1_:hover /*textarea*/
+/* former wa version (v2.2412.xx) */
+._3Uu1_:hover /*textarea*/,
+
+/* updated wa version (v2.3000.xx) */
+div._ak1l:hover /* message text input */
 {
   filter: grayscale(0) opacity(1);
   transition-delay: 0.3s;

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -2,6 +2,7 @@
 /* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
 /* Released under the MIT license, see LICENSE file for details */
 
+/* former wa version (v2.2412.xx) */
 /* mediaGallery */
 body:hover .tukmaf4q /*media preview in gallery*/,
 body:hover ._1Pr6q /*media preview in send media*/,
@@ -55,14 +56,85 @@ body:hover ._3dPH0 /* contacts attachment */,
 body:hover .b021xdil /* multi contacts attachment */,
 body:hover .pz0xruzv /*Details direct profile pic*/,
 body:hover .njub1g37 ._3xH7K /*Details group profile pic*/,
-body:hover .njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/
+body:hover .njub1g37 .kk3akd72.claouzo6 /*Starred message profile pic*/,
+
+/* updated wa version (v2.3000.xx) */
+/* mediaGallery */
+body:hover div._ajuf._ajuh._ajug > div /* media in overlay view */,
+body:hover div.x1conndi /* media thumb in overlay view and details panel */,
+body:hover div.x4t2iug /* media thumb in media gallery panel */,
+
+/* mediaPreview */
+body:hover div._amk4 > ._amk6 :is(div, button)[role="button"]:not(.x13yyeie, ._ak3u, [data-js-context-icon]) /* media messages in chat panel (also quoted message and contact attachment button) */,
+body:hover div._ak4o /* voice note / audio in chat panel */,
+body:hover div._ahy5 > div /* link preview in chat panel */,
+body:hover div._ak15 > ._ahwq /* some link preview in link list panel */,
+body:hover span._ajxd._ajxk > ._ajxj._ajxd /* sticker in chat panel */,
+body:hover div.xz9dduz > div:first-child /* maps / location */,
+body:hover div._ajwt > div:first-child > div:nth-child(2) > div /* media preview in send media */,
+body:hover div._ak3i /* media preview thumb in send media */,
+body:hover div._ajwt .xm0mufa > div /* document filename in send media */,
+
+/* messages */
+body:hover div._amk4 > ._amk6 /* normal message text */,
+body:hover div._amk4 ._am2s /* sticker message */,
+
+/* messagesPreview */
+body:hover div._ak8j /* message preview */,
+
+/* name */
+body:hover div[role="row"] ._ak8q /* user/group name in message list */,
+body:hover div[role="button"][class=""] ._ak8q /* user/group name in details list and popup list */,
+body:hover div[role="dialog"] ._ak8q /* user name in contact popup list */,
+body:hover div[role="dialog"] div.copyable-text /* phone number and business user name in contact popup list */,
+body:hover div[role="row"] ._am_2 /* community name */,
+body:hover div[role="button"]._amie > div:nth-child(1) /* user/group name at the top of chat panel */,
+body:hover div[role="button"]._amie > div:nth-child(2) /* user/group details at the top of chat panel */,
+body:hover div._ahxj /* user name in group chat messages */,
+body:hover div._ahz1 /* user name in contact attachment */,
+body:hover div.xs83m0k.x1iyjqo2.xdl72j9.x18wx58x.x6ikm8r.x10wlt62 /* user name in multiple contacts attachment */,
+body:hover div.overlay ._ak8q /* user name in overlay media view */,
+body:hover h2.xngnso2.x1fcty0u.x2b8uid /* user name in details info */,
+body:hover div.x2b8uid.x193iq5w.xqmxbcd /* group name in details info */,
+body:hover div.x1evy7pa.x1gslohp /* user phone number in details info*/,
+body:hover span.x1lkfr7t.xdbd6k5.x1fcty0u.xw2npq5:nth-child(2) /* user phone number in details info*/,
+body:hover div.x1evy7pa.x1kgmq87.x2b8uid /* group short details in details info */,
+body:hover div.xlm9qay.x1s688f.x1e56ztr /* business user name in details info */,
+body:hover div.xlm9qay.x1s688f.x1e56ztr + div /* business short details in details info */,
+body:hover div.x2b8uid > .xzueoph + div /* business category in details info */,
+body:hover div.xkhd6sd:not([role]) > ._ajxu > div /* business about in details info */,
+body:hover div.xkhd6sd._ajxt > ._ajxu > div /* business phone number in details info */,
+body:hover div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */,
+
+/* profilePic */
+body:hover div[role="row"] ._ak8h /* user/group profile pic in message list */,
+body:hover div[role="button"][class=""] ._ak8h /* user/group profile pic in details list and popup list */,
+body:hover div[role="dialog"] ._ak8h /* user/group profile pic in details list and popup list */,
+body:hover header._amid div[role="button"]:first-child > div /* user/group profile pic at the top of chat panel */,
+body:hover div._amk4 > div[role="button"] /* user profile pic in group chat messages */,
+body:hover div._ahz2 /* user profile pic in contact attachment */,
+body:hover div.x2lah0s.x1c4vz4f.xdl72j9.x194xeti /* user profile pic in multiple contact attachment */,
+body:hover div._ak4m /* user profile pic in voice note chat */,
+body:hover div.overlay ._ak8h /* user profile pic in overlay media view */,
+body:hover div.x78zum5.xl56j7k.x1fqp7bg > div[role="button"] /* user profile pic in details panel */,
+body:hover div[role="button"][class="x1n2onr6 x14yjl9h xudhj91 x18nykt9 xww2gxu"] /* business profile pic in details panel */,
+body:hover div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1 /* business profile banner in details panel */,
+body:hover div.x15e7hw7 /* business profile banner in catalog list */,
+body:hover div._amje /* group profile pic in details panel */,
+body:hover div.overlay ._am0k /* user/group profile pic overlay view */,
+body:hover div.x1okw0bk.x1w0mnb /* user profile pic in starred message list */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0s;
 }
 
+/* former wa version (v2.2412.xx) */
 /* textInput */
-body:hover ._3Uu1_ /*textarea*/
+body:hover ._3Uu1_ /*textarea*/,
+
+/* updated wa version (v2.3000.xx) */
+/* textInput */
+div._ak1l:hover /* message text input */
 {
   filter: grayscale(0) opacity(1);
 }


### PR DESCRIPTION
Update the selectors to support WhatsApp Version 2.3000.1012572464

Tested in my local development environment:
Browser : Brave v1.64.113 with Chromium v123.0.6312.86
OS: Windows 10 22H2 64Bit Build 19045.4170

This should close issue #56 #57 #60 #62 #64 and #65
And after rough checking, this should blur more compared to pull request #61 and #63 

### Changes : 
- Fix blur for Name, Profile Pic, Messages Preview, Messages, Media Preview, Media Gallery and Text Input.
- Move media send preview selectors from `mediaGallery.css` to `mediaPreview.css`
- Exclude padding styles for chat message
- Increase blur for mediaGallery

I leave the former selectors on purpose for version compatibility.

Dear Owner, please review soon @LukasLen , Thank You

Allow me to mention people who might need this 
@Tgentil, @mclorand, @roniekas, @nikhilnk2206, @cruzy67, @Ahmed-Soli, @techsamy, @Usama171, @amithm7, @aritrakrbasu, @UsmanAhmadSaeed, @hndko, @Spacetaxfiling, @GodAnt12, @asim-hawklogix, @vvarl0cks, @satishgadhave, @MvrckTheBald, @ticmaidev, @LivreAcessoPro, @URODESUKA, @fabianodellano, @TejasMishr