### PR TITLE
Adding blur to the tail of a message

### DIFF
--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -9,7 +9,8 @@
 
 /* updated wa version (v2.3000.xx) */
 div._amk4 > ._amk6 /* normal message text */,
-div._amk4 ._am2s /* sticker message */
+div._amk4 ._am2s /* sticker message */,
+span._amk7 /* Tail-out */
 {
   filter: blur(8px) grayscale(1);
   transition-delay: 0s;
@@ -36,7 +37,8 @@ div._amk4 ._am2s /* sticker message */
 
 /* updated wa version (v2.3000.xx) */
 div._amk4 > ._amk6:hover /* normal message text */,
-div._amk4 ._am2s:hover /* sticker message */
+div._amk4 ._am2s:hover /* sticker message */,
+span._amk7:hover /* Tail-out */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;


### PR DESCRIPTION
This PR blurs the tail of the message bubble, addressing a suggestion noted in issue [#68](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/issues/68).

**Before:**
![unblured tail](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/assets/88681055/72fd8036-5464-4baa-b7d8-78a6f78ff714)

**After:**
![FIxed](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/assets/88681055/a14ba85e-286a-4d79-a182-0d612848b662)
