### PR TITLE
Add an option to adjust blur amount for each blur toggles

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -69,6 +69,45 @@
     "toggleUnblurActiveDescription": {
         "message": "Unblurs all when you hover over the WhatsApp Web app."
     },
+    "resetValue": {
+        "message": "Reset Value to Default"
+    },
+    "blurInputLabel": {
+        "message": "Blur amount"
+    },
+    "msBlurInputDescription": {
+        "message": "Set Blur Amount for all messages (in pixel)."
+    },
+    "mspBlurInputDescription": {
+        "message": "Set Blur Amount for messages preview (in pixel)."
+    },
+    "mdpBlurInputDescription": {
+        "message": "Set Blur Amount for media preview (in pixel)."
+    },
+    "mdgBlurInputDescription": {
+        "message": "Set Blur Amount for media gallery (in pixel)."
+    },
+    "ppSmBlurInputLabel": {
+        "message": "Small size blur amount"
+    },
+    "ppSmBlurInputDescription": {
+        "message": "Set Blur Amount for small size profile pic (in pixel)."
+    },
+    "ppBlurInputLabel": {
+        "message": "Normal size blur amount"
+    },
+    "ppBlurInputDescription": {
+        "message": "Set Blur Amount for normal size profile pic (in pixel)."
+    },
+    "ppLgBlurInputLabel": {
+        "message": "Large size blur amount"
+    },
+    "ppLgBlurInputDescription": {
+        "message": "Set Blur Amount for large size profile pic (in pixel)."
+    },
+    "nmBlurInputDescription": {
+        "message": "Set Blur Amount for group/user names (in pixel)."
+    },
     "footerBugReports": {
         "message": "Bug reports & Suggestions"
     },

--- a/src/background.js
+++ b/src/background.js
@@ -24,6 +24,16 @@ const defaultSettings = {
       profilePic: false,
       textInput: true,
       unblurActive: false
+    },
+    varStyles: {
+      mdgBlur: "20px",
+      mdpBlur: "20px",
+      msBlur: "8px",
+      mspBlur: "8px",
+      nmBlur: "5px",
+      ppSmBlur: "3px",
+      ppBlur: "8px",
+      ppLgBlur: "12px",
     }
   }
 };

--- a/src/css/mediaGallery.css
+++ b/src/css/mediaGallery.css
@@ -11,7 +11,7 @@ div._ajuf._ajuh._ajug > div /* media in overlay view */,
 div.x1conndi /* media thumb in overlay view and details panel */,
 div.x4t2iug /* media thumb in media gallery panel */
 {
-  filter: blur(20px) grayscale(1);
+  filter: blur(var(--mdg-blur)) grayscale(1);
   transition-delay: 0s;
 }
 

--- a/src/css/mediaPreview.css
+++ b/src/css/mediaPreview.css
@@ -31,7 +31,7 @@ div._ajwt > div:first-child > div:nth-child(2) > div /* media preview in send me
 div._ak3i /* media preview thumb in send media */,
 div._ajwt .xm0mufa > div /* document filename in send media */
 {
-  filter: blur(20px) grayscale(1);
+  filter: blur(var(--mdp-blur)) grayscale(1);
   transition: initial; /* fix link preview delay */
   transition-delay: 0s;
 }

--- a/src/css/messages.css
+++ b/src/css/messages.css
@@ -11,7 +11,7 @@
 div._amk4 > ._amk6 /* normal message text */,
 div._amk4 ._am2s /* sticker message */
 {
-  filter: blur(8px) grayscale(1);
+  filter: blur(var(--ms-blur)) grayscale(1);
   transition-delay: 0s;
 }
 /* former wa version (v2.2412.xx) */

--- a/src/css/messagesPreview.css
+++ b/src/css/messagesPreview.css
@@ -8,7 +8,7 @@
 /* updated wa version (v2.3000.xx) */
 div._ak8j /*message preview*/
 {
-  filter: blur(8px) grayscale(1);
+  filter: blur(var(--msp-blur)) grayscale(1);
   transition-delay: 0s;
 }
 

--- a/src/css/name.css
+++ b/src/css/name.css
@@ -41,7 +41,7 @@ div.xkhd6sd:not([role]) > ._ajxu > div /* business about in details info */,
 div.xkhd6sd._ajxt > ._ajxu > div /* business phone number details in details info */,
 div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */
 {
-  filter: blur(5px) grayscale(1);
+  filter: blur(var(--nm-blur)) grayscale(1);
   transition-delay: 0s;
 }
 

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -23,7 +23,7 @@ div.x2lah0s.x1c4vz4f.xdl72j9.x194xeti /* user profile pic in multiple contact at
 div._ak4m /* user profile pic in voice note chat */,
 div.overlay ._ak8h /* user profile pic in overlay media view */
 {
-  filter: blur(7px) grayscale(1);
+  filter: blur(var(--pp-blur)) grayscale(1);
   transition-delay: 0s;
 }
 /* former wa version (v2.2412.xx) */
@@ -38,7 +38,7 @@ div.x15e7hw7 /* business profile banner in catalog list */,
 div._amje /* group profile pic in details panel */,
 div.overlay ._am0k /* user/group profile pic overlay view */
 {
-  filter: blur(12px) grayscale(1);
+  filter: blur(var(--pp-lg-blur)) grayscale(1);
   transition-delay: 0s;
 }
 /* former wa version (v2.2412.xx) */
@@ -47,7 +47,7 @@ div.overlay ._am0k /* user/group profile pic overlay view */
 /* updated wa version (v2.3000.xx) */
 div.x1okw0bk.x1w0mnb /* user profile pic in starred message list */
 {
-  filter: blur(3px) grayscale(1);
+  filter: blur(var(--pp-sm-blur)) grayscale(1);
   transition-delay: 0s;
 }
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -37,14 +37,23 @@
           font-size: small;
           display: inline-block;
         }
-        p{
+        #mainContent {
+          margin: 10px 0;
+        }
+        #mainContent > ul > li{
+          position: relative;
           font-size: small;
-          padding: 10px 5px;
+          padding: 10px 5px 0;
+          margin-bottom: 10px;
           border-top: 1px solid #dedede;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          flex-wrap: wrap;
         }
         #mainContent locales {
           display: inline-block;
-          width: 75%;
+          width: 65%;
         }
         button {
           height: 25px;
@@ -64,7 +73,6 @@
         }
         #footer p{
           padding: 0;
-          padding-top: 13px;
           font-size: smaller;
           text-align: center;
         }
@@ -75,6 +83,37 @@
         #popupMessageButton{
           float: right;
           margin: 10px;
+        }
+        .reveal-btn {
+          display: inline-flex;
+          width: 10%;
+          height: 100%;
+          padding: 2px;
+          margin: 0 5px;
+          border: 1px solid #25d366;
+          border-radius: 24px;
+          color: #25d366;
+          background-color: #ffffff;
+          transition: .3s;
+          cursor: pointer;
+        }
+        .reveal-btn:hover {
+          background-color: #25d366;
+          color: #ffffff;
+          border-radius: 4px;
+          transform: rotate(360deg);
+        }
+        .reveal-btn:active, .reveal-btn.active:active {
+          background-color: #ffffffbf;
+          color: #25d366bf;
+        }
+        .reveal-btn.active {
+          background-color: #25d366;
+          color: #ffffff;
+        }
+        .reveal-btn svg {
+          width: 100%;
+          height: 100%;
         }
         input[type=checkbox]{
           height: 0;
@@ -91,7 +130,6 @@
           display: block;
           border-radius: 100px;
           position: relative;
-          top: -2px;
           float: right;
         }
         label:after {
@@ -118,13 +156,118 @@
         label[for="switch"]{
           margin-right: 5px;
         }
+        .collapsible, .var-style, .var-style * {
+          box-sizing: border-box;
+        }
+        .collapsible {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          right: 0;
+          width: 90%;
+          margin: 5px auto;
+          max-height: 0;
+          overflow: hidden;
+          transition: .3s;
+          border-radius: 5px;
+          z-index: 1;
+        }
+        .collapsible.show {
+          max-height: 150px;
+          box-shadow: 0px 2px 5px 1px #23232340;
+        }
+        .var-style {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 8px;
+          font-size: 11px;
+          background-color: #ffffff;
+          width: 100%;
+          height: 100%;
+        }
+        .var-style button[type="reset"] {
+          width: 14%;
+          color: #ff0000;
+          background-color: #ffffff;
+          border: none;
+          margin: 0 4px;
+          height: 100%;
+          display: flex;
+          cursor: pointer;
+        }
+        .var-style button[type="reset"] svg {
+          width: 100%;
+          height: 100%;
+        }
+        .var-style button[type="reset"] svg > g {
+          transition: .15s;
+        }
+        .var-style button[type="reset"]:hover svg > g {
+          stroke-width: 2.5;
+        }
+        .var-style button[type="reset"]:active svg > g {
+          stroke-width: 2;
+        }
+        .var-style input {
+          width: 25px;
+          height: 25px;
+          padding: 0 4px;
+          font-size: 11px;
+          text-align: right;
+          outline: none;
+          border: 1px solid #aaaaaa;
+          border-top-left-radius: 4px;
+          border-bottom-left-radius: 4px;
+          border-right: none;
+        }
+        .var-style input[type="number"] {
+          -webkit-appearance: textfield;
+            -moz-appearance: textfield;
+                  appearance: textfield;
+        }
+        .var-style input[type=number]::-webkit-inner-spin-button, 
+        .var-style input[type=number]::-webkit-outer-spin-button { 
+          -webkit-appearance: none;
+        }
+        .var-style .unit {
+          width: 25px;
+          height: 25px;
+          text-align: center;
+          line-height: 23px;
+          color: #888888;
+          background-color: #dddddd;
+          border-top: 1px solid #aaaaaa;
+          border-bottom: 1px solid #aaaaaa;
+        }
+        .var-style button[type="submit"] {
+          width: 25px;
+          height: 25px;
+          margin: 0;
+          padding: 0;
+          text-align: center;
+          line-height: 23px;
+          outline: none;
+          border: 1px solid #aaaaaa;
+          border-top-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+          background-color: #eeeeee;
+          transition: .3s;
+          cursor: pointer;
+        }
+        .var-style button[type="submit"]:hover {
+          background-color: #dddddd;
+        }
+        .var-style button[type="submit"]:active {
+          background-color: #cccccc;
+        }
       </style>
     </head>
     <body>
       <img src="../images/icon32.png" alt="">
       <h1>Privacy Extension<br>For WhatsApp Web</h1>
       <hr>
-      <span id="mainContent">
+      <div id="mainContent">
         <h2 style="margin-bottom: 10px;">
           <locales data-locale="extensionToggle"></locales>
         </h2>
@@ -136,45 +279,211 @@
         <h2 style="margin-top: 10px; margin-bottom: 5px;">
           <locales data-locale="extensionSettings"></locales>
         </h2>
-        <p>
-          <locales data-locale="toggleMessages"></locales>
-          <input type="checkbox" id="messages" data-style="messages">
-          <label for="messages" data-localetitle="toggleMessagesDescription"/>
-        </p>
-        <p><locales data-locale="toggleMessagesPreview"></locales>
-          <input type="checkbox" id="messagesPreview" data-style="messagesPreview">
-          <label for="messagesPreview" data-localetitle="toggleMessagesPreviewDescription"/>
-        </p>
-        <p><locales data-locale="toggleMediaPreview"></locales>
-          <input type="checkbox" id="mediaPreview" data-style="mediaPreview">
-          <label for="mediaPreview" data-localetitle="toggleMediaPreviewDescription"/>
-        </p>
-        <p><locales data-locale="toggleMediaGallery"></locales>
-          <input type="checkbox" id="mediaGallery" data-style="mediaGallery">
-          <label for="mediaGallery" data-localetitle="toggleMediaGalleryDescription"/>
-        </p>
-        <p><locales data-locale="toggleTextInput"></locales>
-          <input type="checkbox" id="textInput" data-style="textInput">
-          <label for="textInput" data-localetitle="toggleTextInputDescription"/>
-        </p>
-        <p><locales data-locale="toggleProfilePic"></locales>
-          <input type="checkbox" id="profilePic" data-style="profilePic">
-          <label for="profilePic" data-localetitle="toggleProfilePicDescription"/>
-        </p>
-        <p><locales data-locale="toggleName"></locales>
-          <input type="checkbox" id="name" data-style="name">
-          <label for="name" data-localetitle="toggleNameDescription"/>
-        </p>
-        <p><locales data-locale="toggleNoDelay"></locales>
-          <input type="checkbox" id="noDelay" data-style="noDelay">
-          <label for="noDelay" data-localetitle="toggleNoDelayDescription"/>
-        </p>
-        <p><locales data-locale="toggleUnblurActive"></locales>
-          <input type="checkbox" id="unblurActive" data-style="unblurActive">
-          <label for="unblurActive" data-localetitle="toggleUnblurActiveDescription"/>
-        </p>
-      </span>
+        <ul>
+          <li>
+            <locales data-locale="toggleMessages"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="messages" data-style="messages">
+            <label for="messages" data-localetitle="toggleMessagesDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="blurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="msBlur" id="msBlur" data-var-name="msBlur" value="8" data-localetitle="msBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="msBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleMessagesPreview"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="messagesPreview" data-style="messagesPreview">
+            <label for="messagesPreview" data-localetitle="toggleMessagesPreviewDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="blurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="mspBlur" id="mspBlur" data-var-name="mspBlur" value="8" data-localetitle="mspBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="mspBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleMediaPreview"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="mediaPreview" data-style="mediaPreview">
+            <label for="mediaPreview" data-localetitle="toggleMediaPreviewDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="blurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="mdpBlur" id="mdpBlur" data-var-name="mdpBlur" value="20" data-localetitle="mdpBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="mdpBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleMediaGallery"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="mediaGallery" data-style="mediaGallery">
+            <label for="mediaGallery" data-localetitle="toggleMediaGalleryDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="blurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="mdgBlur" id="mdgBlur" data-var-name="mdgBlur" value="20" data-localetitle="mdgBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="mdgBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleTextInput"></locales>
+            <input type="checkbox" id="textInput" data-style="textInput">
+            <label for="textInput" data-localetitle="toggleTextInputDescription"></label>
+          </li>
+          <li>
+            <locales data-locale="toggleProfilePic"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="profilePic" data-style="profilePic">
+            <label for="profilePic" data-localetitle="toggleProfilePicDescription"></label> 
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="ppSmBlurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="ppSmBlur" id="ppSmBlur" data-var-name="ppSmBlur" value="3" data-localetitle="ppSmBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="ppSmBlurInputDescription">✔</button>
+              </form>
+              <form class="var-style">
+                <locales data-locale="ppBlurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="ppBlur" id="ppBlur" data-var-name="ppBlur" value="5" data-localetitle="ppBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="ppBlurInputDescription">✔</button>
+              </form>
+              <form class="var-style">
+                <locales data-locale="ppLgBlurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="ppLgBlur" id="ppLgBlur" data-var-name="ppLgBlur" value="12" data-localetitle="ppLgBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="ppLgBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleName"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="name" data-style="name">
+            <label for="name" data-localetitle="toggleNameDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="blurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10" d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="nmBlur" id="nmBlur" data-var-name="nmBlur" value="5" data-localetitle="nmBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="nmBlurInputDescription">✔</button>
+              </form>
+            </div>
+          </li>
+          <li>
+            <locales data-locale="toggleNoDelay"></locales>
+            <input type="checkbox" id="noDelay" data-style="noDelay">
+            <label for="noDelay" data-localetitle="toggleNoDelayDescription"></label>
+          </li>
+          <li>
+            <locales data-locale="toggleUnblurActive"></locales>
+            <input type="checkbox" id="unblurActive" data-style="unblurActive">
+            <label for="unblurActive" data-localetitle="toggleUnblurActiveDescription"></label>
+          </li>
+        </ul>
+
+      </div>
       <span id="popupMessage"></span>
+      <hr>
       <div id="footer">
         <p><a href="mailto:contact@lukaslen.com" data-localetitle="footerBugReportsDescription" target="_blank"><locales data-locale="footerBugReports"></locales></a> - <a href="https://lukaslen.com" title="by Lukas Lenhardt" target="_blank"><locales data-locale="footerAuthor"></locales></a>
         <br>v<span id="version">0.0.0</span> - <a href="https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/releases" data-localetitle="footerReleaseNotesDescription" target="_blank"><locales data-locale="footerReleaseNotes"></locales></a></p>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -42,6 +42,33 @@ function saveSettings() {
   });
 }
 
+// toggle open/close blur amount settings
+const showBlurSettings = (ev) => {
+  ev.currentTarget.classList.toggle("active");
+  ev.currentTarget.parentNode.querySelector(".collapsible").classList.toggle("show");
+}
+const revealButtons = document.querySelectorAll(".reveal-btn");
+revealButtons.forEach((revealBtn) => {
+  revealBtn.addEventListener("click", showBlurSettings)
+})
+
+// track form save/submit for variable style settings
+const forms = document.querySelectorAll("form.var-style");
+
+forms.forEach((form) => {
+  form.addEventListener("submit", saveFormSettings);
+})
+function saveFormSettings(ev) {
+  ev.preventDefault();
+  const [key, val] = Object.entries(Object.fromEntries(new FormData(ev.target)))[0];
+
+  browser.storage.sync.get([settingsIdentifier]).then((result) => {
+    if (!result.hasOwnProperty(settingsIdentifier)) return;
+    result.settings.varStyles[key] = val + "px";
+    browser.storage.sync.set(result);
+  });
+}
+
 // Load settings and update switches
 browser.storage.sync.get([settingsIdentifier]).then((result) => {
   if (!result.hasOwnProperty(settingsIdentifier)) return;
@@ -54,6 +81,14 @@ browser.storage.sync.get([settingsIdentifier]).then((result) => {
       checkbox.checked = result.settings.styles[id];
     }
   });
+
+  // set variable input value
+  forms.forEach((form) => {
+    const numInput = form.querySelector(`input[type="number"]`)
+    const varName = numInput.dataset.varName;
+    numInput.value = parseInt(result.settings.varStyles[varName]);
+  })
+  
 });
 
 

--- a/src/scripts/contentScript.js
+++ b/src/scripts/contentScript.js
@@ -36,6 +36,31 @@ function addStyleById(id) {
   document.getElementsByTagName("head")[0].appendChild(link);
 }
 
+// variable style
+function addVarStyle([varName, value]) {
+  if (document.getElementById(varName)) removeStyleById(varName);
+
+  const kebabize = (str) => str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (s, ofs) => (ofs ? "-" : "") + s.toLowerCase());
+
+  const innerText = `
+  #whatsapp-web body {
+    --${kebabize(varName)}: ${value};
+  }
+  `
+
+  const varStyleEl = document.getElementById(varName);
+  if (varStyleEl) {
+    varStyleEl.innerText = innerText;
+    return;
+  };
+
+  var styleEl = document.createElement('style');
+  styleEl.id = varName;
+  styleEl.className = "pfwa-variables";
+  styleEl.innerText = innerText;
+  document.getElementsByTagName("head")[0].appendChild(styleEl);
+}
+
 function updateStyles() {
   browser.storage.sync.get([settingsIdentifier]).then((result) => {
     if (result == null || !result.settings.on) {
@@ -51,6 +76,13 @@ function updateStyles() {
         removeStyleById(style);
       }
     });
+
+    // update variable styles
+    const varStyles = Object.entries(result.settings.varStyles);
+    varStyles.forEach((varStyle) => {
+      addVarStyle(varStyle);
+    })
+    
   });
 }
 


### PR DESCRIPTION
Add new Feature to adjust blur amount, as requested in issue #12 

Tested on :
WhatsApp: v2.3000.1012850706
OS: Windows 10 22H2 64Bit Build 19045.4170
Browser: Brave Browser v1.64.122 with Chromium v123.0.6312.122 and Firefox v125.0.1

#### Example:
Default:
![image](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/assets/66844553/780b53ef-01d0-4ab0-ad76-280e8e3cbf4a)
> Button will open or close the extra option. Options can only be closed by clicking option toggle again


Custom Blur Amount:
![image](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/assets/66844553/f7760237-60b8-44a6-807b-14f64a7293e1)
> Click Submit Button after changing value, to apply changes. 
> Reset button will reset value to default, then you still need to Submit to apply changes.

