### PR TITLE
Add New Feature: Blur On Idle

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -68,6 +68,12 @@
     "toggleUnblurActiveDescription": {
         "message": "Unblurs all when you hover over the WhatsApp Web app."
     },
+    "toggleBlurOnIdle": {
+        "message": "Blur WhatsApp on Idle"
+    },
+    "toggleBlurOnIdleDescription": {
+        "message": "Blur WhatsApp when there is no mouse/keyboard activity after a certain time."
+    },
     "resetValue": {
         "message": "Reset Value to Default"
     },
@@ -106,6 +112,18 @@
     },
     "nmBlurInputDescription": {
         "message": "Set Blur Amount for group/user names (in pixel)."
+    },
+    "itBlurInputLabel": {
+        "message": "Idle Timeout"
+    },
+    "itBlurInputDescription": {
+        "message": "Set timeout of inactivity (in seconds)."
+    },
+    "wiBlurInputLabel": {
+        "message": "Blur amount"
+    },
+    "wiBlurInputDescription": {
+        "message": "Set Blur Amount when Idle."
     },
     "footerBugReports": {
         "message": "Bug reports & Suggestions"

--- a/src/background.js
+++ b/src/background.js
@@ -34,6 +34,11 @@ const defaultSettings = {
       ppSmBlur: "3px",
       ppBlur: "8px",
       ppLgBlur: "12px",
+      wiBlur: "14px",
+    },
+    blurOnIdle: {
+      isEnabled: false,
+      idleTimeout: 15,
     }
   }
 };

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -479,6 +479,52 @@
             <input type="checkbox" id="unblurActive" data-style="unblurActive">
             <label for="unblurActive" data-localetitle="toggleUnblurActiveDescription"></label>
           </li>
+          <li>
+            <locales data-locale="toggleBlurOnIdle"></locales>
+            <button type="button" class="reveal-btn">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path fill="currentColor"
+                  d="M12 15.5A3.5 3.5 0 0 1 8.5 12A3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64z" />
+              </svg>
+            </button>
+            <input type="checkbox" id="blurOnIdle" data-style="blurOnIdle">
+            <label for="blurOnIdle" data-localetitle="toggleBlurOnIdleDescription"></label>
+            <div class="collapsible">
+              <form class="var-style">
+                <locales data-locale="itBlurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10"
+                        d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="itBlur" id="itBlur" data-var-name="itBlur" value="15"
+                  data-localetitle="itBlurInputDescription">
+                <span class="unit">s</span>
+                <button type="submit" data-localetitle="itBlurInputDescription">✔</button>
+              </form>
+              <form class="var-style">
+                <locales data-locale="wiBlurInputLabel"></locales>
+                <button type="reset" data-localetitle="resetValue">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5">
+                      <path stroke-miterlimit="10"
+                        d="M6.395 7.705A7.885 7.885 0 0 1 12 5.382a7.929 7.929 0 0 1 7.929 7.929A7.94 7.94 0 0 1 12 21.25a7.939 7.939 0 0 1-7.929-7.94" />
+                      <path stroke-linejoin="round" d="m7.12 2.75l-.95 3.858a1.332 1.332 0 0 0 .97 1.609l3.869.948" />
+                    </g>
+                  </svg>
+                </button>
+                <input type="number" name="wiBlur" id="wiBlur" data-var-name="wiBlur" value="14"
+                  data-localetitle="wiBlurInputDescription">
+                <span class="unit">px</span>
+                <button type="submit" data-localetitle="wiBlurInputDescription">✔</button>
+              </form>
+              </div>
+          
+          </li>
         </ul>
 
       </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -35,6 +35,8 @@ function saveSettings() {
     if (!result.hasOwnProperty(settingsIdentifier)) return;
     if (id == "on") {
       result.settings.on = checked;
+    } else if (id === "blurOnIdle") {
+      result.settings.blurOnIdle.isEnabled = checked;
     } else {
       result.settings.styles[id] = checked;
     }
@@ -64,7 +66,11 @@ function saveFormSettings(ev) {
 
   browser.storage.sync.get([settingsIdentifier]).then((result) => {
     if (!result.hasOwnProperty(settingsIdentifier)) return;
-    result.settings.varStyles[key] = val + "px";
+    if (key === "itBlur") {
+      result.settings.blurOnIdle.idleTimeout = val;
+    } else {
+      result.settings.varStyles[key] = val + "px";
+    }
     browser.storage.sync.set(result);
   });
 }
@@ -77,6 +83,8 @@ browser.storage.sync.get([settingsIdentifier]).then((result) => {
     let id = checkbox.dataset.style;
     if (id == "on") {
       checkbox.checked = result.settings.on;
+    } else if (id === "blurOnIdle") {
+      checkbox.checked = result.settings?.blurOnIdle?.isEnabled;
     } else {
       checkbox.checked = result.settings.styles[id];
     }
@@ -86,7 +94,11 @@ browser.storage.sync.get([settingsIdentifier]).then((result) => {
   forms.forEach((form) => {
     const numInput = form.querySelector(`input[type="number"]`)
     const varName = numInput.dataset.varName;
-    numInput.value = parseInt(result.settings.varStyles[varName]);
+    if (varName === "itBlur") {
+      numInput.value = parseInt(result.settings?.blurOnIdle?.idleTimeout || 15);
+    } else {
+      numInput.value = parseInt(result.settings.varStyles[varName]);
+    }
   })
   
 });

--- a/src/scripts/contentScript.js
+++ b/src/scripts/contentScript.js
@@ -61,10 +61,15 @@ function addVarStyle([varName, value]) {
   document.getElementsByTagName("head")[0].appendChild(styleEl);
 }
 
-function updateStyles() {
+function updateStyles(changes) {
   browser.storage.sync.get([settingsIdentifier]).then((result) => {
     if (result == null || !result.settings.on) {
       removeAllStyles();
+      
+      if (timers?.timerObj) {
+        removeTimer();
+      }
+
       return;
     }
     
@@ -83,15 +88,147 @@ function updateStyles() {
       addVarStyle(varStyle);
     })
     
+    // update blur on idle
+    setBlurOnIdle(changes, result);
+
   });
 }
 
 // Update styles on setting change
 browser.storage.onChanged.addListener((changes, area) => {
   if (area == "sync" && changes.settings != null) {
-    updateStyles();
+    updateStyles(changes);
   }
 });
 
 // Initial update once page loaded
 updateStyles();
+
+/**
+ * timer
+ *
+ * Run idleCallback if user idle for idleTime,
+ * then run activeCallback if any events happen
+ * 
+ * @param {Object} opts
+ * @param {function} opts.idleCallback - fired when user is idle
+ * @param {function} opts.activeCallback - fired when user is active
+ * @param {number} opts.idleTime - time in milliseconds  
+ * @param {[string]} [opts.events] - event listeners. Default to : ["pointermove", "pointerdown", "keydown"]
+ * 
+ */
+const timer = (opts) => {
+  options = opts || {};
+  const idleCallback = options.idleCallback || function () { };
+  const activeCallback = options.activeCallback || function () { };
+  const idleTime = options.idleTime || 1000;
+  const events = options.events || ["pointermove", "pointerdown", "keydown"];
+  let isActive = true;
+  let isEnabled = true;
+  let timer;
+
+  function addOrRemoveEvents(addOrRemove) {
+    events.forEach((eventName) => {
+      document[addOrRemove](eventName, triggerActive);
+    });
+  }
+
+  function enable() {
+    isEnabled = true;
+    addOrRemoveEvents("addEventListener");
+    triggerActive();
+  }
+
+  function triggerActive() {
+    if (!isActive) {
+      isActive = true;
+      activeCallback();
+    }
+    clearTimeout(timer);
+    timer = setTimeout(triggerIdle, idleTime);
+  }
+  
+  function triggerIdle() {
+    if (!isActive) return;
+    isActive = false;
+    idleCallback();
+  }
+
+  function disable() {
+    isActive = true;
+    isEnabled = false;
+    clearTimeout(timer);
+    addOrRemoveEvents('removeEventListener');
+  }
+
+  return {
+    isEnabled: () => isEnabled,
+    enable: enable,
+    disable: disable,
+    triggerActive: triggerActive,
+    triggerIdle: triggerIdle
+  };
+}
+
+const timers = {};
+
+// blur page 
+const blurBody = () => {
+  document.body.style.filter = "blur(var(--wi-blur)) grayscale(1)";
+  document.body.style.transition = "filter .3s linear";
+}
+// unblur page 
+const unblurBody = () => {
+  document.body.style.filter = "";
+}
+
+// disable and remove timer if exist
+const removeTimer = () => {
+  timers.timerObj.triggerActive();
+  timers.timerObj.disable();
+  delete timers.timerObj;
+}
+
+const setBlurOnIdle = (changes, result) => {
+
+  const previousState = changes?.settings?.oldValue?.blurOnIdle;
+  const currentState = changes?.settings?.newValue?.blurOnIdle ?? result.settings?.blurOnIdle;
+  const isPreviousEnabled = previousState?.isEnabled;
+  const isCurrentEnabled = currentState?.isEnabled;
+  const isBlurOnIdleChanged = isPreviousEnabled !== isCurrentEnabled;
+  const isIdleTimeoutChanged = previousState?.idleTimeout !== currentState?.idleTimeout;
+
+  if (isCurrentEnabled && (isBlurOnIdleChanged || changes?.settings?.oldValue?.on === false)) {
+    if (timers?.timerObj) {
+      removeTimer();
+    }
+    // create new timer
+    const newTimer = timer({
+      idleCallback: blurBody,
+      activeCallback: unblurBody,
+      idleTime: parseInt(currentState?.idleTimeout * 1000 || 15000),
+    });
+    timers.timerObj = newTimer;
+    timers.timerObj.enable();
+  } else if (isCurrentEnabled && isBlurOnIdleChanged === false) {
+    if (isIdleTimeoutChanged) {
+      if (timers?.timerObj) {
+        removeTimer();
+      }
+      // then create new timer
+      const newTimer = timer({
+        idleCallback: blurBody,
+        activeCallback: unblurBody,
+        idleTime: parseInt(currentState?.idleTimeout * 1000 || 15000),
+      });
+      timers.timerObj = newTimer;
+      timers.timerObj.enable();
+    }
+  } else if (isCurrentEnabled === false && isBlurOnIdleChanged) {
+    if (timers?.timerObj) {
+      removeTimer();
+    }
+  }
+
+}
+


### PR DESCRIPTION
Add new feature: Blur on Idle (#25)
WhatsApp will get blurred when there is no mouse/keyboard activity after a determined seconds (default: 15s). Blur amount also adjustable.

It detects `pointermove`, `pointerdown`, and `keydown` events in document, scrolling not included.

Tested on :
WhatsApp: v2.3000.1014222212
OS: Windows 10 22H2 64Bit Build 19045.4412
Browser: Brave Browser v1.67.116 with Chromium v126.0.6478.71 and Firefox v127.0

Result : 
![image](https://github.com/LukasLen/Privacy-Extension-For-WhatsApp-Web/assets/66844553/d439ef01-4170-4bb2-b573-49234afefaea)
