### PR TITLE
Fix blur for message text input

### DIFF
--- a/src/css/noDelay.css
+++ b/src/css/noDelay.css
@@ -128,7 +128,8 @@ div.overlay ._am0k:hover /* user/group profile pic overlay view */,
 div.x1okw0bk.x1w0mnb:hover /* user profile pic in starred message list */,
 
 /* textInput */
-div._ak1l:hover /* message text input */
+div._ak1l:hover /* message text input */,
+div._ak1r:hover /* message text input */
 {
   transition-delay: 0.04s !important;
   -webkit-transition-duration: 0s !important;

--- a/src/css/textInput.css
+++ b/src/css/textInput.css
@@ -3,19 +3,21 @@
 /* Released under the MIT license, see LICENSE file for details */
 
 /* former wa version (v2.2412.xx) */
-._3Uu1_ /*textarea*/,
+._3Uu1_ /* textarea */,
 
 /* updated wa version (v2.3000.xx) */
-div._ak1l /* message text input */
+div._ak1l /* message text input */,
+div._ak1r /* message text input */
 {
   filter: grayscale(1) opacity(0.25);
 }
 
 /* former wa version (v2.2412.xx) */
-._3Uu1_:hover /*textarea*/,
+._3Uu1_:hover /* textarea */,
 
 /* updated wa version (v2.3000.xx) */
-div._ak1l:hover /* message text input */
+div._ak1l:hover /* message text input */,
+div._ak1r:hover /* message text input */
 {
   filter: grayscale(0) opacity(1);
   transition-delay: 0.3s;

--- a/src/css/unblurActive.css
+++ b/src/css/unblurActive.css
@@ -134,7 +134,8 @@ body:hover ._3Uu1_ /*textarea*/,
 
 /* updated wa version (v2.3000.xx) */
 /* textInput */
-div._ak1l:hover /* message text input */
+div._ak1l:hover /* message text input */,
+div._ak1r:hover /* message text input */
 {
   filter: grayscale(0) opacity(1);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "action": {
     "default_title": "__MSG_extensionName__",
     "default_popup": "popup/popup.html",

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "action": {
     "default_title": "__MSG_extensionName__",
     "default_popup": "popup/popup.html",


### PR DESCRIPTION
This PR addresses issue #93 by introducing the new ak1r selector for the message text input. The previous ak1l selector is retained to prevent retroactive errors for users on older WhatsApp Web versions.