### PR TITLE
Add auto hide/show chat list feature

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -74,6 +74,12 @@
     "toggleBlurOnIdleDescription": {
         "message": "Verstecke WhatsApp nach einer gewissen Zeit, sobald keine Maus/Tastatur Eingabe erkannt wird."
     },
+    "toggleHideChatList": {
+        "message": "Chat-Liste automatisch ein-/ausblenden"
+    },
+    "toggleHideChatListDescription": {
+        "message": "Die Chat-Liste öffnet sich, wenn die Maus in der Nähe der linken Seite ist, und schließt sich, wenn die Maus wegbewegt wird."
+    },
     "resetValue": {
         "message": "Zurücksetzen"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -74,6 +74,12 @@
     "toggleBlurOnIdleDescription": {
         "message": "Blur WhatsApp when there is no mouse/keyboard activity after a certain time."
     },
+    "toggleHideChatList": {
+        "message": "Auto hide/show chat list"
+    },
+    "toggleHideChatListDescription": {
+        "message": "Chat list slides open when mouse is near the left side and collapses when mouse moves away."
+    },
     "resetValue": {
         "message": "Reset Value to Default"
     },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -74,6 +74,12 @@
     "toggleBlurOnIdleDescription": {
         "message": "Desfoca o WhatsApp quando não há atividade de mouse/teclado após um certo tempo."
     },
+    "toggleHideChatList": {
+        "message": "Ocultar/mostrar lista de conversas automaticamente"
+    },
+    "toggleHideChatListDescription": {
+        "message": "A lista de conversas desliza para abrir quando o mouse está próximo ao lado esquerdo e recolhe quando o mouse se afasta."
+    },
     "resetValue": {
         "message": "Redefinir Valor para Padrão"
     },

--- a/src/background.js
+++ b/src/background.js
@@ -22,7 +22,8 @@ const defaultSettings = {
       noDelay: false,
       profilePic: false,
       textInput: true,
-      unblurActive: false
+      unblurActive: false,
+      hideChatList: false
     },
     varStyles: {
       mdgBlur: "20px",

--- a/src/css/hideChatList.css
+++ b/src/css/hideChatList.css
@@ -1,0 +1,32 @@
+/* Privacy Extension for WhatsApp(TM) Web                       */
+/* Copyright (c) 2024 Lukas Lenhardt - lukaslen.com             */
+/* Released under the MIT license, see LICENSE file for details */
+
+/* Chat list container - collapsed by default */
+[data-pfwa-chat-list] {
+    display: flex !important;
+    max-width: 0 !important;
+    width: 100% !important;
+    transition: max-width 0.35s ease-out, opacity 0.35s ease-out !important;
+    overflow: hidden !important;
+}
+
+/* Header inside chat list - hidden by default */
+[data-pfwa-chat-list] header {
+    opacity: 0 !important;
+    transition: opacity 0.35s ease-out !important;
+}
+
+/* Remove border */
+.x1t7ytsu {
+    border-inline-start-style: none !important;
+}
+
+/* Expanded state - controlled by JavaScript */
+[data-pfwa-chat-list].pfwa-chat-list-expanded {
+    max-width: 400px !important;
+}
+
+[data-pfwa-chat-list].pfwa-chat-list-expanded header {
+    opacity: 1 !important;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -43,7 +43,8 @@
         "css/profilePic.css",
         "css/name.css",
         "css/noDelay.css",
-        "css/unblurActive.css"
+        "css/unblurActive.css",
+        "css/hideChatList.css"
       ],
       "matches": ["https://web.whatsapp.com/*"]
     }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -522,8 +522,13 @@
                 <span class="unit">px</span>
                 <button type="submit" data-localetitle="wiBlurInputDescription">✔</button>
               </form>
-              </div>
-          
+            </div>
+
+          </li>
+          <li>
+            <locales data-locale="toggleHideChatList"></locales>
+            <input type="checkbox" id="hideChatList" data-style="hideChatList">
+            <label for="hideChatList" data-localetitle="toggleHideChatListDescription"></label>
           </li>
         </ul>
 

--- a/src/scripts/contentScript.js
+++ b/src/scripts/contentScript.js
@@ -70,6 +70,11 @@ function updateStyles(changes) {
         removeTimer();
       }
 
+      // Disable chat list auto-hide when extension is off
+      if (chatListAutoHide.isEnabled()) {
+        chatListAutoHide.disable();
+      }
+
       return;
     }
     
@@ -77,8 +82,18 @@ function updateStyles(changes) {
     styles.forEach((style) => {
       if (result.settings.styles[style]) {
         addStyleById(style);
+
+        // Enable chat list auto-hide when hideChatList is enabled
+        if (style === "hideChatList") {
+          chatListAutoHide.enable();
+        }
       } else {
         removeStyleById(style);
+
+        // Disable chat list auto-hide when hideChatList is disabled
+        if (style === "hideChatList") {
+          chatListAutoHide.disable();
+        }
       }
     });
 
@@ -232,3 +247,107 @@ const setBlurOnIdle = (changes, result) => {
 
 }
 
+/**
+ * chat list auto-hide
+ * 
+ * Show chat list on mouse hover near left edge,
+ * hide when mouse moves away
+ * 
+ * @returns {{isEnabled: function(): boolean, enable: function(): void, disable: function(): void}} control object
+ * @property {function(): boolean} isEnabled - returns whether auto-hide is currently enabled
+ * @property {function(): void} enable - activates chat list auto-hide functionality
+ * @property {function(): void} disable - deactivates chat list auto-hide and cleans up
+ */
+
+const CHAT_LIST_SELECTOR = "#app > div > div > div:nth-of-type(3) > div > div:nth-of-type(4)";
+const CHAT_LIST_ATTR = "data-pfwa-chat-list";
+
+const chatListAutoHide = (() => {
+  let isEnabled = false;
+  let observer = null;
+  let lastMouse = { x: 9999, y: 9999 };
+
+  const config = {
+    chatWidth: 400,
+    chatOpenThreshold: 400,
+    chatClosedThreshold: 80,
+    hideThreshold: 80
+  };
+
+  function getChatListElement() {
+    return document.querySelector(CHAT_LIST_SELECTOR);
+  }
+
+  function updateVisibility(evt) {
+    if (!isEnabled) return;
+
+    if (evt && typeof evt.clientX === "number") {
+      lastMouse.x = evt.clientX;
+      lastMouse.y = evt.clientY;
+    }
+
+    const chatList = getChatListElement();
+    if (!chatList) return;
+
+    if (!chatList.hasAttribute(CHAT_LIST_ATTR)) {
+      chatList.setAttribute(CHAT_LIST_ATTR, "");
+    }
+
+    const mouseX = evt?.clientX ?? lastMouse.x;
+
+    if (mouseX <= config.hideThreshold) {
+      chatList.classList.add("pfwa-chat-list-expanded");
+      config.hideThreshold = config.chatOpenThreshold;
+    } else {
+      chatList.classList.remove("pfwa-chat-list-expanded");
+      config.hideThreshold = config.chatClosedThreshold;
+    }
+  }
+
+  function addOrRemoveEvents(addOrRemove) {
+    document[addOrRemove]("mousemove", updateVisibility);
+    document[addOrRemove]("mouseleave", () => updateVisibility());
+  }
+
+  function enable() {
+    if (isEnabled) return;
+    isEnabled = true;
+
+    addOrRemoveEvents("addEventListener");
+
+    observer = new MutationObserver(() => {
+      updateVisibility();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+
+    updateVisibility();
+  }
+
+  function disable() {
+    if (!isEnabled) return;
+    isEnabled = false;
+
+    addOrRemoveEvents("removeEventListener");
+
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+
+    const chatList = getChatListElement();
+    if (chatList) {
+      chatList.classList.remove("pfwa-chat-list-expanded");
+      chatList.removeAttribute(CHAT_LIST_ATTR);
+    }
+  }
+
+  return {
+    isEnabled: () => isEnabled,
+    enable: enable,
+    disable: disable
+  };
+})();


### PR DESCRIPTION
This PR is just a suggestion of something I’ve been using for a while to improve privacy before I knew about this extension. I thought it would be nice to have here as it complements the existing collection of privacy features.

This adds a new feature that automatically hides the chat list and reveals it only when the mouse approaches the left edge of the screen.

![demo-wpp](https://github.com/user-attachments/assets/1f74db8b-53be-4b44-8974-7344b4877fef)

### Feature Behavior

- Mouse Near Left Edge (X ≤ 80px): Chat list expands to ~400px
- Mouse Moves Away (X > 400px): Chat list collapses back

### Notes About Implementation

This feature uses the selector:

```js
const CHAT_LIST_SELECTOR = "#app > div > div > div:nth-of-type(3) > div > div:nth-of-type(4)";
```

This differs from other parts of the project that use class selectors. I chose this approach because in my userscript version every time WhatsApp updated I had to fix the selector. So I'm trying this DOM path approach to see if it's more stable. However, I'm open to refactoring this if maintainers prefer a different approach.

Please let me know if there's anything to adjust. Thanks for this great extension.