### PR TITLE
Add blur support for chat list elements

### DIFF
--- a/src/css/name.css
+++ b/src/css/name.css
@@ -19,6 +19,11 @@ div[role="button"] > div > ._8nE1Y ._21S-L /*user/group name in non message list
 
 /* updated wa version (v2.3000.xx) */
 div[role="listitem"] ._ak8q /* user/group name in message list */,
+div[role="row"] ._ak8q /* user/group name in chat list */,
+div[role="row"] ._ak8o ._ak8q /* user/group name in chat list (nested) */,
+div[role="row"] span[title][dir="auto"] /* user/group name in chat list with title */,
+div[role="listitem"] span._ak8q /* user/group name in message list (additional wrapper) */,
+div[role="listitem"] span[title] /* user/group name in message list (title attribute) */,
 div[role="button"][class=""] ._ak8q /* user/group name in details list and popup list */,
 div[role="dialog"] ._ak8q /* user name in contact popup list */,
 div[role="dialog"] div.copyable-text /* phone number and business user name in contact popup list */,
@@ -62,6 +67,11 @@ div[role="button"] > div > ._8nE1Y ._21S-L:hover /*user/group name in non messag
 
 /* updated wa version (v2.3000.xx) */
 div[role="listitem"] ._ak8q:hover /* user/group name in message list */,
+div[role="row"] ._ak8q:hover /* user/group name in chat list */,
+div[role="row"] ._ak8o ._ak8q:hover /* user/group name in chat list (nested) */,
+div[role="row"] span[title][dir="auto"]:hover /* user/group name in chat list with title */,
+div[role="listitem"] span._ak8q:hover /* user/group name in message list (additional wrapper) */,
+div[role="listitem"] span[title]:hover /* user/group name in message list (title attribute) */,
 div[role="button"][class=""] ._ak8q:hover /* user/group name in details list and popup list */,
 div[role="dialog"] ._ak8q:hover /* user name in contact popup list */,
 div[role="dialog"] div.copyable-text:hover /* phone number and business user name in contact popup list */,


### PR DESCRIPTION
## Description
This PR adds blur support for additional chat list elements in WhatsApp Web version 2.3000.xx.

## Changes
- Added CSS selectors for user/group names in chat lists with various structures
- Added support for nested chat list elements
- Added hover states for all new selectors
- Maintained consistency with existing blur/unblur patterns

## Affected Selectors
- `div[role="row"] ._ak8q` - user/group name in chat list
- `div[role="row"] ._ak8o ._ak8q` - nested chat list elements
- `div[role="row"] span[title][dir="auto"]` - chat list with title attribute
- `div[role="listitem"] span._ak8q` - message list with additional wrapper
- `div[role="listitem"] span[title]` - message list with title attribute

## Testing
- Tested with WhatsApp Web v2.3000.xx
- Verified blur effect applies correctly
- Confirmed hover states work as expected