### PR TITLE
feat: add updated WA selectors and bump version

### DIFF
--- a/src/css/messagesPreview.css
+++ b/src/css/messagesPreview.css
@@ -6,7 +6,8 @@
 .vQ0w7 /*message preview*/,
 
 /* updated wa version (v2.3000.xx) */
-div._ak8k /*message preview*/
+div._ak8k /*message preview*/,
+div.x1fc57z9:not(.x1716072):not(.x1bvqhpb) /*message preview*/
 {
   filter: blur(var(--msp-blur)) grayscale(1);
   transition-delay: 0s;
@@ -16,7 +17,8 @@ div._ak8k /*message preview*/
 .vQ0w7:hover /*message preview*/,
 
 /* updated wa version (v2.3000.xx) */
-div._ak8k:hover /*message preview*/
+div._ak8k:hover /*message preview*/,
+div.x1fc57z9:not(.x1716072):not(.x1bvqhpb):hover /*message preview*/
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/name.css
+++ b/src/css/name.css
@@ -39,7 +39,8 @@ div.xlm9qay.x1s688f.x1e56ztr + div /* business short details in details info */,
 div.x2b8uid > .xzueoph + div /* business category in details info */,
 div.xkhd6sd:not([role]) > ._ajxu > div /* business about in details info */,
 div.xkhd6sd._ajxt > ._ajxu > div /* business phone number details in details info */,
-div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */
+div._ak1d > div:first-child > div:first-child > :not(:first-child) /* user/group name in starred message list */,
+div.xggjnk3 /* user/group in list */
 {
   filter: blur(var(--nm-blur)) grayscale(1);
   transition-delay: 0s;
@@ -82,7 +83,8 @@ div.xlm9qay.x1s688f.x1e56ztr + div:hover /* business short details in details in
 div.x2b8uid > .xzueoph + div:hover /* business category in details info */,
 div.xkhd6sd:not([role]) > ._ajxu > div:hover /* business about in details info */,
 div.xkhd6sd._ajxt > ._ajxu > div:hover /* business phone number in details info */,
-div._ak1d > div:first-child > div:first-child > :not(:first-child):hover /* user/group name in starred message list */
+div._ak1d > div:first-child > div:first-child > :not(:first-child):hover /* user/group name in starred message list */,
+div.xggjnk3:hover /* user/group in list */
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/profilePic.css
+++ b/src/css/profilePic.css
@@ -36,7 +36,10 @@ div[role="button"][class="x1n2onr6 x14yjl9h xudhj91 x18nykt9 xww2gxu"] /* busine
 div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1 /* business profile banner in details panel */,
 div.x15e7hw7 /* business profile banner in catalog list */,
 div.x1n2onr6.x1oysuqx.x1m3v4wt.x1gryazu.xkrivgy /* group profile pic in details panel */,
-div.overlay:not([data-animate-media-viewer]) ._ajuf._ajuh > div /* user/group profile pic overlay view */
+div.overlay:not([data-animate-media-viewer]) ._ajuf._ajuh > div /* user/group profile pic overlay view */,
+
+/* updated wa version */
+div.xeusxvb
 {
   filter: blur(var(--pp-lg-blur)) grayscale(1);
   transition-delay: 0s;
@@ -80,7 +83,8 @@ div.x10l6tqk.x13vifvy.x17qophe.xh8yej3.xiqx3za.x6ikm8r.x10wlt62.x1knukwh.xihgre1
 div.x15e7hw7:hover /* business profile banner in catalog list */,
 div.x1n2onr6.x1oysuqx.x1m3v4wt.x1gryazu.xkrivgy:hover /* group profile pic in details panel */,
 div.overlay:not([data-animate-media-viewer]) ._ajuf._ajuh > div:hover /* user/group profile pic overlay view */,
-div.x1okw0bk.x1w0mnb:hover /* user profile pic in starred message list */
+div.x1okw0bk.x1w0mnb:hover /* user profile pic in starred message list */,
+div.xeusxvb:hover
 {
   filter: blur(0) grayscale(0);
   transition-delay: 0.3s;

--- a/src/css/textInput.css
+++ b/src/css/textInput.css
@@ -7,7 +7,8 @@
 
 /* updated wa version (v2.3000.xx) */
 div._ak1l /* message text input */,
-div._ak1r /* message text input */
+div._ak1r /* message text input */,
+div.x1716072 /* message text input */
 {
   filter: grayscale(1) opacity(0.25);
 }
@@ -17,7 +18,8 @@ div._ak1r /* message text input */
 
 /* updated wa version (v2.3000.xx) */
 div._ak1l:hover /* message text input */,
-div._ak1r:hover /* message text input */
+div._ak1r:hover /* message text input */,
+div.x1716072:hover /* message text input */
 {
   filter: grayscale(0) opacity(1);
   transition-delay: 0.3s;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "action": {
     "default_title": "__MSG_extensionName__",
     "default_popup": "popup/popup.html",


### PR DESCRIPTION
Update CSS to target new WhatsApp class names so blur/hover behavior continues to work with the updated WA layout (v2.3000.xx). Changes include:
- messagesPreview.css: add div.x1fc57z9 selector for message previews and hover state.
- name.css: add div.xggjnk3 to blur user/group names in lists and on hover.
- profilePic.css: add div.xeusxvb to apply blur/hover to profile images/banners.
- textInput.css: add div.x1716072 to target the message text input and its hover state. 
Also bump manifest.json version from 3.3.2 to 3.3.3.